### PR TITLE
Feat/#41 희망직무 조회/업데이트 API 구현

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/job/entity/Job.java
+++ b/src/main/java/org/sopt/certi_server/domain/job/entity/Job.java
@@ -28,7 +28,4 @@ public class Job {
 	@Column(name = "name", nullable = false)
 	private String name;
 
-	@ManyToOne(fetch = FetchType.LAZY, targetEntity = User.class)
-	@JoinColumn(name = "user_id", nullable = false)
-	private User user;
 }

--- a/src/main/java/org/sopt/certi_server/domain/job/repository/JobRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/job/repository/JobRepository.java
@@ -1,8 +1,10 @@
 package org.sopt.certi_server.domain.job.repository;
 
+import java.util.Optional;
+
 import org.sopt.certi_server.domain.job.entity.Job;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JobRepository extends JpaRepository<Job, Long> {
-	Job findByName(String name);
+	Optional<Job> findByName(String name);
 }

--- a/src/main/java/org/sopt/certi_server/domain/job/repository/JobRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/job/repository/JobRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.certi_server.domain.job.repository;
+
+import org.sopt.certi_server.domain.job.entity.Job;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobRepository extends JpaRepository<Job, Long> {
+	Job findByName(String name);
+}

--- a/src/main/java/org/sopt/certi_server/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/controller/UserController.java
@@ -33,17 +33,17 @@ public class UserController {
 
 	@GetMapping("/job")
 	public ResponseEntity<SuccessResponse<GetJobResponse>> getUserJob(
-		//@AuthenticationPrincipal Long userId
+		@AuthenticationPrincipal Long userId
 	){
-		GetJobResponse jobResponse = userService.getUserJob(1L);
+		GetJobResponse jobResponse = userService.getUserJob(userId);
 		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, jobResponse));
 	}
 	@PostMapping("/job")
-	public ResponseEntity<SuccessResponse> updatehUserJob(
-		//@AuthenticationPrincipal Long userId,
+	public ResponseEntity<SuccessResponse> updateUserJob(
+		@AuthenticationPrincipal Long userId,
 		@RequestBody UpdateJobRequest updateJobRequest
 	){
-		userService.updateUserJob(1L, updateJobRequest.jobNameList());
+		userService.updateUserJob(userId, updateJobRequest.jobNameList());
 		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_UPDATE));
 	}
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package org.sopt.certi_server.domain.user.controller;
 
+import org.sopt.certi_server.domain.user.dto.request.UpdateJobRequest;
+import org.sopt.certi_server.domain.user.dto.response.GetJobResponse;
 import org.sopt.certi_server.domain.user.dto.response.GetUserResponse;
 import org.sopt.certi_server.domain.user.service.UserService;
 import org.sopt.certi_server.global.error.code.SuccessCode;
@@ -8,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,15 +19,31 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/user")
 public class UserController {
 	private final UserService userService;
 
-	@GetMapping("/home/user")
+	@GetMapping
 	public ResponseEntity<SuccessResponse<GetUserResponse>> getHomeUser(
 		@AuthenticationPrincipal Long userId
 		){
 		GetUserResponse getUserResponse = userService.getHomeUser(userId);
 		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, getUserResponse));
+	}
+
+	@GetMapping("/job")
+	public ResponseEntity<SuccessResponse<GetJobResponse>> getUserJob(
+		//@AuthenticationPrincipal Long userId
+	){
+		GetJobResponse jobResponse = userService.getUserJob(1L);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, jobResponse));
+	}
+	@PostMapping("/job")
+	public ResponseEntity<SuccessResponse> updatehUserJob(
+		//@AuthenticationPrincipal Long userId,
+		@RequestBody UpdateJobRequest updateJobRequest
+	){
+		userService.updateUserJob(1L, updateJobRequest.jobNameList());
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_UPDATE));
 	}
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/request/UpdateJobRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/request/UpdateJobRequest.java
@@ -1,0 +1,16 @@
+package org.sopt.certi_server.domain.user.dto.request;
+
+import java.util.List;
+
+import org.sopt.certi_server.global.error.code.ErrorCode;
+import org.sopt.certi_server.global.error.exception.BadRequestException;
+
+public record UpdateJobRequest(
+	List<String> jobNameList
+) {
+	public UpdateJobRequest {
+		if(jobNameList.isEmpty() || jobNameList.size() > 3){
+			throw new BadRequestException(ErrorCode.JOB_SIZE_ERROR);
+		}
+	}
+}

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/request/UpdateJobRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/request/UpdateJobRequest.java
@@ -5,12 +5,11 @@ import java.util.List;
 import org.sopt.certi_server.global.error.code.ErrorCode;
 import org.sopt.certi_server.global.error.exception.BadRequestException;
 
+import jakarta.validation.constraints.Size;
+
 public record UpdateJobRequest(
+	@Size(min = 1, max = 3, message = "희망 직무는 1~3개까지 선택가능합니다")
 	List<String> jobNameList
-) {
-	public UpdateJobRequest {
-		if(jobNameList == null || jobNameList.size() > 3){
-			throw new BadRequestException(ErrorCode.JOB_SIZE_ERROR);
-		}
-	}
+){
+
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/request/UpdateJobRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/request/UpdateJobRequest.java
@@ -9,7 +9,7 @@ public record UpdateJobRequest(
 	List<String> jobNameList
 ) {
 	public UpdateJobRequest {
-		if(jobNameList.isEmpty() || jobNameList.size() > 3){
+		if(jobNameList == null || jobNameList.size() > 3){
 			throw new BadRequestException(ErrorCode.JOB_SIZE_ERROR);
 		}
 	}

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/response/GetJobResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/response/GetJobResponse.java
@@ -1,0 +1,11 @@
+package org.sopt.certi_server.domain.user.dto.response;
+
+import java.util.List;
+
+public record GetJobResponse(
+	List<String> jobList
+	) {
+	public static GetJobResponse of(List<String> jobList) {
+		return new GetJobResponse(jobList);
+	}
+}

--- a/src/main/java/org/sopt/certi_server/domain/user/entity/UserJob.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/entity/UserJob.java
@@ -12,9 +12,15 @@ import jakarta.persistence.IdClass;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Table(name = "user_job")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserJob {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,4 +34,10 @@ public class UserJob {
 	@JoinColumn(name = "job_id")
 	private Job job;
 
+	@Builder
+	public UserJob(Long id, User user, Job job) {
+		this.id = id;
+		this.user = user;
+		this.job = job;
+	}
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/repository/UserJobRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/repository/UserJobRepository.java
@@ -1,0 +1,13 @@
+package org.sopt.certi_server.domain.user.repository;
+
+import java.util.List;
+
+import org.sopt.certi_server.domain.user.entity.User;
+import org.sopt.certi_server.domain.user.entity.UserJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJobRepository extends JpaRepository<UserJob,Long> {
+	List<UserJob> findAllByUserId(Long userId);
+
+	void deleteAllByUser(User user);
+}

--- a/src/main/java/org/sopt/certi_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/UserService.java
@@ -66,7 +66,8 @@ public class UserService {
         //새로운 값으로 갱신
         List<UserJob> userJobList = jobNameList.stream()
             .map(jobName -> {
-                Job job = jobRepository.findByName(jobName);
+                Job job = jobRepository.findByName(jobName)
+                    .orElseThrow(() -> new NotFoundException(ErrorCode.JOB_NOT_FOUND));
                 return UserJob.builder()
                     .job(job)
                     .user(user)

--- a/src/main/java/org/sopt/certi_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/UserService.java
@@ -1,13 +1,20 @@
 package org.sopt.certi_server.domain.user.service;
 
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 
-import org.sopt.certi_server.domain.major.entity.Major;
+import org.sopt.certi_server.domain.job.entity.Job;
+import org.sopt.certi_server.domain.job.repository.JobRepository;
 import org.sopt.certi_server.domain.major.entity.MajorImpl;
 import org.sopt.certi_server.domain.major.repository.MajorImplRepository;
+import org.sopt.certi_server.domain.user.dto.request.UpdateJobRequest;
+import org.sopt.certi_server.domain.user.dto.response.GetJobResponse;
 import org.sopt.certi_server.domain.user.dto.response.GetUserResponse;
 import org.sopt.certi_server.domain.user.entity.User;
+import org.sopt.certi_server.domain.user.entity.UserJob;
 import org.sopt.certi_server.domain.user.entity.UserMajorImpl;
+import org.sopt.certi_server.domain.user.repository.UserJobRepository;
 import org.sopt.certi_server.domain.user.repository.UserMajorImplRepository;
 import org.sopt.certi_server.domain.user.repository.UserRepository;
 import org.sopt.certi_server.global.error.code.ErrorCode;
@@ -23,6 +30,8 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserMajorImplRepository userMajorImplRepository;
     private final MajorImplRepository majorImplRepository;
+    private final UserJobRepository userJobRepository;
+    private final JobRepository jobRepository;
 
     public User getUser(Long userId){
         return userRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
@@ -34,5 +43,37 @@ public class UserService {
         MajorImpl majorImpl = majorImplRepository.findById(userMajor.getMajorImpl().getId())
             .orElseThrow(()-> new NotFoundException(ErrorCode.DATA_NOT_FOUND));
         return GetUserResponse.from(user, majorImpl);
+    }
+
+    public GetJobResponse getUserJob(final Long userId){
+        getUser(userId);
+        List<UserJob> userJobList = userJobRepository.findAllByUserId(userId);
+        List<String> jobNameList = userJobList.stream()
+            .map(UserJob::getJob)
+            .map(Job::getName)
+            .toList();
+
+        return GetJobResponse.of(jobNameList);
+    }
+
+    @Transactional
+    public void updateUserJob(final Long userId, final List<String> jobNameList){
+        User user = getUser(userId);
+
+        //기존 값 삭제
+        userJobRepository.deleteAllByUser(user);
+
+        //새로운 값으로 갱신
+        List<UserJob> userJobList = jobNameList.stream()
+            .map(jobName -> {
+                Job job = jobRepository.findByName(jobName);
+                return UserJob.builder()
+                    .job(job)
+                    .user(user)
+                    .build();
+            })
+            .toList();
+
+        userJobRepository.saveAll(userJobList);
     }
 }

--- a/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
+++ b/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 	TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "E400005", "요청 값 타입이 올바르지 않습니다"),
 	DATA_INTEGRITY_VIOLATION(HttpStatus.BAD_REQUEST, "E400006", "데이터 무결성 제약 조건을 위반했습니다"),
 	TEST_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "E400006", "요청 테스트 타입이 올바르지 않습니다"),
+	JOB_SIZE_ERROR(HttpStatus.BAD_REQUEST, "E400007", "희망 분야는 1~3개까지 선택가능합니다"),
 
 	/* 401 */
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E401001", "리소스 접근 권한이 없습니다."),

--- a/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
+++ b/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
 
 	DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "E404001", "데이터가 존재하지 않습니다"),
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "E404002", "유저가 존재하지 않습니다"),
+	JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "E404003", "직무가 존재하지 않습니다"),
 
 	/* 409 CONFLICT */
 

--- a/src/main/java/org/sopt/certi_server/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/certi_server/global/filter/JwtAuthenticationFilter.java
@@ -68,6 +68,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (method.equals(HttpMethod.GET.name())) {
             return EXCLUDE_URL.stream().anyMatch(exclude -> new AntPathMatcher().match(exclude, path));
         }
+        if (method.equals(HttpMethod.POST.name())) {
+            return EXCLUDE_URL.stream().anyMatch(exclude -> new AntPathMatcher().match(exclude, path));
+        }
         return false;
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

- close #41 

## 📝 Summary

- 희망직무 조회 API
- 희망직무 업데이트 API

## 📬 Postman

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/626620ee-76d7-4653-9888-4868e2d15bf8" />
![image](https://github.com/user-attachments/assets/e109d26a-2d64-4bf5-b4e7-21ab2a611ab8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 직무 정보를 조회하고 수정할 수 있는 API 엔드포인트가 추가되었습니다.
  * 직무 목록을 반환하는 응답 및 직무 수정 요청을 위한 데이터 전송 객체가 도입되었습니다.

* **버그 수정**
  * 직무 선택 시 1~3개만 허용하도록 검증 및 오류 코드가 추가되었습니다.

* **개선사항**
  * 사용자-직무 연관관계 관리가 개선되어, 직무 정보 갱신이 더 간편해졌습니다.
  * 인증 필터가 일부 POST 요청도 예외 처리하도록 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->