### PR TITLE
[feat] #45 취득, 취득 예정 중복에 대한 unique constraints 추가

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/acquisition/controller/AcquisitionController.java
+++ b/src/main/java/org/sopt/certi_server/domain/acquisition/controller/AcquisitionController.java
@@ -15,8 +15,8 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/acquire")
-public class AcquireController {
+@RequestMapping("/api/v1/acquisition")
+public class AcquisitionController {
 	private final AcquisitionService acquisitionService;
 
 	@PostMapping("/{certificationId}")

--- a/src/main/java/org/sopt/certi_server/domain/acquisition/entity/Acquisition.java
+++ b/src/main/java/org/sopt/certi_server/domain/acquisition/entity/Acquisition.java
@@ -16,6 +16,12 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "acquisition",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "certification_id"})
+        }
+)
 public class Acquisition extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/sopt/certi_server/domain/acquisition/entity/enums/CardType.java
+++ b/src/main/java/org/sopt/certi_server/domain/acquisition/entity/enums/CardType.java
@@ -9,15 +9,24 @@ import java.util.concurrent.ThreadLocalRandom;
 @RequiredArgsConstructor
 public enum CardType {
 
-    FIRST("", ""), SECOND("", ""), THIRD("", ""), FOURTH("", "");
+    FIRST("https://sopt-certi-bucket.s3.ap-northeast-2.amazonaws.com/certi/color%3Dblue.png", "https://sopt-certi-bucket.s3.ap-northeast-2.amazonaws.com/certi/Property+1%3D1.png",0),
+    SECOND("https://sopt-certi-bucket.s3.ap-northeast-2.amazonaws.com/certi/color%3Dskyblue.png", "https://sopt-certi-bucket.s3.ap-northeast-2.amazonaws.com/certi/Property+1%3D2.png",1),
+    THIRD("https://sopt-certi-bucket.s3.ap-northeast-2.amazonaws.com/certi/color%3Dwhite.png", "https://sopt-certi-bucket.s3.ap-northeast-2.amazonaws.com/certi/Property+1%3D3.png",2),
+    FOURTH("https://sopt-certi-bucket.s3.ap-northeast-2.amazonaws.com/certi/color%3Dyellow.png", "https://sopt-certi-bucket.s3.ap-northeast-2.amazonaws.com/certi/Property+1%3D4.png",3);
 
     private final String cardFrontImageUrl;
     private final String cardBackImageUrl;
+    private final int index;
 
     private static final CardType[] VALUES = values();
+    public static final int CARD_TOTAL = 4;
 
     public static CardType issueRandomCardType(){
         int index = ThreadLocalRandom.current().nextInt(VALUES.length);
         return VALUES[index];
+    }
+
+    public static CardType issueNextCardType(int index){
+        return VALUES[(index + 1) % CARD_TOTAL];
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/acquisition/repository/AcquisitionRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/acquisition/repository/AcquisitionRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import javax.swing.text.html.Option;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +16,6 @@ public interface AcquisitionRepository extends JpaRepository<Acquisition, Long> 
 
 	@Query("select ac from Acquisition ac join fetch ac.certification where ac.user = :user")
 	List<Acquisition> findByUserOrderByIdAsc(User user);
+
+	Optional<Acquisition> findFirstByUserOrderByCreatedTimeDesc(User user);
 }

--- a/src/main/java/org/sopt/certi_server/domain/acquisition/service/AcquisitionService.java
+++ b/src/main/java/org/sopt/certi_server/domain/acquisition/service/AcquisitionService.java
@@ -18,6 +18,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
+
+import static org.sopt.certi_server.domain.acquisition.entity.enums.CardType.*;
+import static org.sopt.certi_server.domain.acquisition.entity.enums.CardType.CARD_TOTAL;
 
 @Service
 @RequiredArgsConstructor
@@ -27,14 +31,20 @@ public class AcquisitionService {
 	private final UserService userService;
 	private final CertificationService certificationService;
 
+
 	@Transactional
 	public String createAcquisition(final Long userId, final Long certificationId){
 		Certification certification = certificationService.getCertification(certificationId);
 		User user = userService.getUser(userId);
 
-		CardType cardType = CardType.issueRandomCardType();
+		CardType cardType = acquisitionRepository.findFirstByUserOrderByCreatedTimeDesc(user)
+				.map(acquisition -> {
+					int index = acquisition.getCardType().getIndex();
+					return issueNextCardType(index);
+				}).orElseGet(CardType::issueRandomCardType);
 
-		Acquisition acquisition = org.sopt.certi_server.domain.acquisition.entity.Acquisition.builder()
+
+		Acquisition acquisition = Acquisition.builder()
 			.user(user)
 			.certification(certification)
 			.cardType(cardType)

--- a/src/main/java/org/sopt/certi_server/domain/certification/dto/request/CertificationCreateRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/dto/request/CertificationCreateRequest.java
@@ -6,6 +6,7 @@ import java.util.List;
 public record CertificationCreateRequest(
         String certificationName,
         Long agencyId,
+        String certificationType,
         String testType,
         String averagePeriod,
         Long charge,

--- a/src/main/java/org/sopt/certi_server/domain/certification/entity/Certification.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/entity/Certification.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.sopt.certi_server.domain.certification.entity.enums.CertificationType;
 import org.sopt.certi_server.domain.certification.entity.enums.TestType;
 import org.sopt.certi_server.global.entity.BaseTimeEntity;
 
@@ -27,6 +28,9 @@ public class Certification extends BaseTimeEntity {
     private Agency agency;
 
     private String name;
+
+    @Enumerated(value = EnumType.STRING)
+    private CertificationType certificationType;
 
     @Enumerated(value = EnumType.STRING)
     private TestType testType;
@@ -55,12 +59,13 @@ public class Certification extends BaseTimeEntity {
     private String applicationUrl;
 
     @Builder
-    public Certification(Long id, Agency agency, String name, TestType testType, String averagePeriod, Long charge,
+    public Certification(Long id, Agency agency, String name, CertificationType certificationType, TestType testType, String averagePeriod, Long charge,
         List<String> tags, String description, String testDateInformation, LocalDate nearestTestDate,
         String applicationMethod, String cardImageUrl, String applicationUrl) {
         this.id = id;
         this.agency = agency;
         this.name = name;
+        this.certificationType = certificationType;
         this.testType = testType;
         this.averagePeriod = averagePeriod;
         this.charge = charge;

--- a/src/main/java/org/sopt/certi_server/domain/certification/entity/enums/CertificationType.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/entity/enums/CertificationType.java
@@ -19,8 +19,11 @@ public enum CertificationType {
     private final String koreanName;
 
     public static CertificationType from(String koreanName) {
+        if(koreanName == null){
+            throw new NotFoundException(ErrorCode.CERTIFICATION_TYPE_NOT_FOUND);
+        }
         return Arrays.stream(CertificationType.values())
-                .filter(ct -> ct.koreanName.equalsIgnoreCase(koreanName))
+                .filter(ct -> ct.koreanName.equals(koreanName))
                 .findFirst()
                 .orElseThrow(() -> new NotFoundException(ErrorCode.CERTIFICATION_TYPE_NOT_FOUND));
     }

--- a/src/main/java/org/sopt/certi_server/domain/certification/entity/enums/CertificationType.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/entity/enums/CertificationType.java
@@ -1,0 +1,27 @@
+package org.sopt.certi_server.domain.certification.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.certi_server.global.error.code.ErrorCode;
+import org.sopt.certi_server.global.error.exception.NotFoundException;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+@Getter
+public enum CertificationType {
+
+    NATIONAL_TECHNICAL("국가기술자격"),
+    NATIONAL_PROFESSIONAL("국가전문자격"),
+    PRIVATE("민간자격"),
+    LANGUAGE("어학자격");
+
+    private final String koreanName;
+
+    public static CertificationType from(String koreanName) {
+        return Arrays.stream(CertificationType.values())
+                .filter(ct -> ct.koreanName.equalsIgnoreCase(koreanName))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException(ErrorCode.CERTIFICATION_TYPE_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/sopt/certi_server/domain/certification/entity/enums/TestType.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/entity/enums/TestType.java
@@ -18,6 +18,9 @@ public enum TestType {
     private final String type;
 
     public static TestType from(String typeName) {
+        if(typeName == null){
+
+        }
         return Arrays.stream(TestType.values())
             .filter(t -> t.type.equalsIgnoreCase(typeName))
             .findFirst()

--- a/src/main/java/org/sopt/certi_server/domain/certification/entity/enums/TestType.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/entity/enums/TestType.java
@@ -13,10 +13,9 @@ import org.sopt.certi_server.global.error.exception.NotFoundException;
 public enum TestType {
     WRITTEN("필기형"),
     PRACTICAL("실기형"),
-    COMBINED("종합형");
+    COMBINED("복합형");
 
     private final String type;
-
 
     public static TestType from(String typeName) {
         return Arrays.stream(TestType.values())

--- a/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
@@ -2,6 +2,7 @@ package org.sopt.certi_server.domain.certification.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.certi_server.domain.certification.entity.Agency;
+import org.sopt.certi_server.domain.certification.entity.enums.CertificationType;
 import org.sopt.certi_server.domain.certification.repository.AgencyRepository;
 import org.sopt.certi_server.domain.certification.entity.Category;
 import org.sopt.certi_server.domain.certification.dto.request.CertificationCreateRequest;
@@ -33,8 +34,9 @@ public class CertificationService {
     @Transactional
     public void createCertification(CertificationCreateRequest request) {
         Agency findAgency = getAgency(request);
+        CertificationType certificationType = CertificationType.from(request.certificationType());
         TestType testType = TestType.from(request.testType());
-        Certification newCertification = convertDtoToEntity(request, testType, findAgency);
+        Certification newCertification = convertDtoToEntity(request, certificationType, testType, findAgency);
         certificationRepository.save(newCertification);
     }
 
@@ -46,10 +48,11 @@ public class CertificationService {
         return agencyRepository.findById(request.agencyId()).orElseThrow(() -> new NotFoundException(ErrorCode.DATA_NOT_FOUND));
     }
 
-    private Certification convertDtoToEntity(CertificationCreateRequest request, TestType testType, Agency agency) {
+    private Certification convertDtoToEntity(CertificationCreateRequest request, CertificationType certificationType, TestType testType, Agency agency) {
         return Certification.builder()
                 .agency(agency)
                 .name(request.certificationName())
+                .certificationType(certificationType)
                 .testType(testType)
                 .averagePeriod(request.averagePeriod())
                 .charge(request.charge())

--- a/src/main/java/org/sopt/certi_server/domain/user/entity/enums/Grade.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/entity/enums/Grade.java
@@ -19,8 +19,11 @@ public enum Grade {
     private final String grade;
 
     public static Grade from(String grade) {
+        if(grade == null){
+            throw new NotFoundException(ErrorCode.GRADE_NOT_FOUND);
+        }
         return Arrays.stream(Grade.values())
-            .filter(g -> g.grade.equalsIgnoreCase(grade))
+            .filter(g -> g.grade.equals(grade))
             .findFirst()
             .orElseThrow(() -> new NotFoundException(ErrorCode.GRADE_NOT_FOUND));
     }

--- a/src/main/java/org/sopt/certi_server/domain/user/entity/enums/TrackType.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/entity/enums/TrackType.java
@@ -24,6 +24,9 @@ public enum TrackType {
 	private final String name;
 
 	public static TrackType from(String name){
+		if(name == null){
+			throw new NotFoundException(ErrorCode.TRACK_NOT_FOUND);
+		}
 		return Arrays.stream(TrackType.values())
 				.filter(t -> t.name.equalsIgnoreCase(name))
 				.findFirst()

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/dto/response/PreCertificationSimple.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/dto/response/PreCertificationSimple.java
@@ -7,10 +7,11 @@ public record PreCertificationSimple(
         String certificationName,
         String averagePeriod,
         String testDate,
-        String agencyName
+        String agencyName,
+        String iconImageUrl
 ) {
 
     public static PreCertificationSimple from(UserPreCertification upc){
-        return new PreCertificationSimple(upc.getCertification().getId(), upc.getCertification().getName(), upc.getCertification().getAveragePeriod(),upc.getCertification().getTestDateInformation(), upc.getCertification().getAgency().getName());
+        return new PreCertificationSimple(upc.getCertification().getId(), upc.getCertification().getName(), upc.getCertification().getAveragePeriod(),upc.getCertification().getTestDateInformation(), upc.getCertification().getAgency().getName(), upc.getIconType().getIconImageUrl());
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/entity/UserPreCertification.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/entity/UserPreCertification.java
@@ -7,12 +7,19 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.certi_server.domain.certification.entity.Certification;
 import org.sopt.certi_server.domain.user.entity.User;
+import org.sopt.certi_server.domain.userprecertification.entity.enums.IconType;
+import org.sopt.certi_server.global.entity.BaseTimeEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "user_pre_certification")
-public class UserPreCertification {
+@Table(
+        name = "user_pre_certification",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "certification_id"})
+        }
+)
+public class UserPreCertification extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -24,16 +31,21 @@ public class UserPreCertification {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Enumerated(value = EnumType.STRING)
+    private IconType iconType;
+
     @Builder
-    public UserPreCertification(User user, Certification certification) {
+    public UserPreCertification(User user, Certification certification, IconType iconType) {
         this.user = user;
         this.certification = certification;
+        this.iconType = iconType;
     }
 
-    public static UserPreCertification create(User user, Certification certification) {
+    public static UserPreCertification create(User user, Certification certification, IconType iconType) {
         return UserPreCertification.builder()
                 .user(user)
                 .certification(certification)
+                .iconType(iconType)
                 .build();
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/entity/enums/IconType.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/entity/enums/IconType.java
@@ -10,9 +10,9 @@ import java.util.concurrent.ThreadLocalRandom;
 @Getter
 public enum IconType {
 
-    FIRST("", 0),
-    SECOND("", 1),
-    THIRD("", 2);
+    FIRST("https://sopt-certi-bucket.s3.ap-northeast-2.amazonaws.com/certi/serti_emoji-2.png", 0),
+    SECOND("https://sopt-certi-bucket.s3.ap-northeast-2.amazonaws.com/certi/serti_emoji-3.png", 1),
+    THIRD("https://sopt-certi-bucket.s3.ap-northeast-2.amazonaws.com/certi/serti_emoji.png", 2);
 
     private final String iconImageUrl;
     private final int index;

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/entity/enums/IconType.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/entity/enums/IconType.java
@@ -1,0 +1,32 @@
+package org.sopt.certi_server.domain.userprecertification.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.certi_server.domain.acquisition.entity.enums.CardType;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+@RequiredArgsConstructor
+@Getter
+public enum IconType {
+
+    FIRST("", 0),
+    SECOND("", 1),
+    THIRD("", 2);
+
+    private final String iconImageUrl;
+    private final int index;
+
+    private static final IconType[] VALUES = values();
+    public static final int ICON_TOTAL = 3;
+
+
+    public static IconType issueRandomIconType(){
+        int index = ThreadLocalRandom.current().nextInt(VALUES.length);
+        return VALUES[index];
+    }
+
+    public static IconType issueNextIconType(int index){
+        return VALUES[(index + 1) % ICON_TOTAL];
+    }
+}

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/repository/UserPreCertificationRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/repository/UserPreCertificationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserPreCertificationRepository extends JpaRepository<UserPreCertification, Long> {
 
@@ -17,10 +18,12 @@ public interface UserPreCertificationRepository extends JpaRepository<UserPreCer
             select upc 
             from UserPreCertification upc 
             join fetch upc.certification c 
-            join fetch c.agency
+            left join fetch c.agency
             where upc.user.id = :userId
             """)
     List<UserPreCertification> getPreCertificationsByUserId(Long userId);
+
+    Optional<UserPreCertification> findFirstByUserOrderByCreatedTimeDesc(User user);
 
     void deleteByUserAndCertification(User user, Certification certification);
 

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/service/UserPreCertificationService.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/service/UserPreCertificationService.java
@@ -11,6 +11,7 @@ import org.sopt.certi_server.domain.userprecertification.dto.request.UserPreCert
 import org.sopt.certi_server.domain.userprecertification.dto.response.PreCertificationSimple;
 import org.sopt.certi_server.domain.userprecertification.dto.response.PreCertificationSimpleListResponse;
 import org.sopt.certi_server.domain.userprecertification.entity.UserPreCertification;
+import org.sopt.certi_server.domain.userprecertification.entity.enums.IconType;
 import org.sopt.certi_server.domain.userprecertification.repository.UserPreCertificationRepository;
 import org.sopt.certi_server.global.error.code.ErrorCode;
 import org.sopt.certi_server.global.error.exception.NotFoundException;
@@ -27,8 +28,6 @@ public class UserPreCertificationService {
     private final UserService userService;
     private final CertificationService certificationService;
     private final UserPreCertificationRepository userPreCertificationRepository;
-    private final UserRepository userRepository;
-    private final CertificationRepository certificationRepository;
 
     public PreCertificationSimpleListResponse getPreCertificationListDataByUserId(Long userId) {
         return new PreCertificationSimpleListResponse(userPreCertificationRepository.getPreCertificationsByUserId(userId).stream().map(
@@ -40,7 +39,12 @@ public class UserPreCertificationService {
     public void createNewPreCertification(Long userId, Long preCertificationId) {
         User user = userService.getUser(userId);
         Certification certification = certificationService.getCertification(preCertificationId);
-        userPreCertificationRepository.save(UserPreCertification.create(user, certification));
+
+        IconType iconType = userPreCertificationRepository.findFirstByUserOrderByCreatedTimeDesc(user)
+                .map(userPreCertification -> IconType.issueNextIconType(userPreCertification.getIconType().getIndex()))
+                .orElseGet(IconType::issueRandomIconType);
+
+        userPreCertificationRepository.save(UserPreCertification.create(user, certification, iconType));
     }
 
     @Transactional

--- a/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
+++ b/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
 	GRADE_NOT_FOUND(HttpStatus.NOT_FOUND, "E40405", "존재하지 않는 학년입니다."),
 	SOCIAL_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "E40406", "존재하지 않는 소셜 타입입니다."),
 	TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "E40407", "존재하지 않는 계열입니다."),
+	CERTIFICATION_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "E40408", "존재하지 않는 자격증 종류입니다."),
 
 
 	/* 409 CONFLICT */

--- a/src/main/java/org/sopt/certi_server/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/certi_server/global/handler/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package org.sopt.certi_server.global.handler;
 
 import java.io.IOException;
+import java.util.PriorityQueue;
+import java.util.Queue;
 
 import org.sopt.certi_server.global.error.code.ErrorCode;
 import org.sopt.certi_server.global.error.dto.ErrorResponse;

--- a/src/test/java/org/sopt/certi_server/domain/userprecertification/service/UserPreCertificationServiceTest.java
+++ b/src/test/java/org/sopt/certi_server/domain/userprecertification/service/UserPreCertificationServiceTest.java
@@ -1,0 +1,101 @@
+package org.sopt.certi_server.domain.userprecertification.service;
+
+import jakarta.persistence.EntityManager;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.Test;
+import org.sopt.certi_server.domain.certification.entity.Certification;
+import org.sopt.certi_server.domain.certification.repository.CertificationRepository;
+import org.sopt.certi_server.domain.user.entity.User;
+import org.sopt.certi_server.domain.user.repository.UserRepository;
+import org.sopt.certi_server.domain.user.service.UserService;
+import org.sopt.certi_server.domain.userprecertification.entity.UserPreCertification;
+import org.sopt.certi_server.domain.userprecertification.entity.enums.IconType;
+import org.sopt.certi_server.domain.userprecertification.repository.UserPreCertificationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.InitBinder;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserPreCertificationServiceTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    CertificationRepository certificationRepository;
+
+    @Autowired
+    UserPreCertificationRepository userPreCertificationRepository;
+
+    @Autowired
+    UserPreCertificationService userPreCertificationService;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @Transactional
+    @Rollback(value = false)
+    void preCertificationTest(){
+        // given
+        User user = User.createUser("lee", "ekjs", "asdf");
+        userRepository.save(user);
+        Certification certification1 = Certification.builder()
+                .name("정처기1")
+                .build();
+
+        Certification certification2 = Certification.builder()
+                .name("정처기2")
+                .build();
+
+        Certification certification3 = Certification.builder()
+                .name("정처기3")
+                .build();
+
+        Certification certification4 = Certification.builder()
+                .name("정처기4")
+                .build();
+
+        Certification certification5 = Certification.builder()
+                .name("정처기5")
+                .build();
+
+        Certification certification6 = Certification.builder()
+                .name("정처기6")
+                .build();
+
+        certificationRepository.save(certification1);
+        certificationRepository.save(certification2);
+        certificationRepository.save(certification3);
+        certificationRepository.save(certification4);
+        certificationRepository.save(certification5);
+        certificationRepository.save(certification6);
+
+        em.flush();
+        em.clear();
+
+        // when
+        userPreCertificationService.createNewPreCertification(user.getId(), certification1.getId());
+        userPreCertificationService.createNewPreCertification(user.getId(), certification2.getId());
+        userPreCertificationService.createNewPreCertification(user.getId(), certification3.getId());
+        userPreCertificationService.createNewPreCertification(user.getId(), certification4.getId());
+        userPreCertificationService.createNewPreCertification(user.getId(), certification5.getId());
+        userPreCertificationService.createNewPreCertification(user.getId(), certification6.getId());
+
+        // then
+        List<UserPreCertification> preCertificationsByUserId = userPreCertificationRepository.getPreCertificationsByUserId(user.getId());
+
+        System.out.println("preCertificationsByUserId.size() = " + preCertificationsByUserId.size());
+        for (UserPreCertification userPreCertification : preCertificationsByUserId) {
+            System.out.println("userPreCertification.getIconType().getIndex() = " + userPreCertification.getIconType().getIndex());
+        }
+    }
+
+}


### PR DESCRIPTION
## 📣 Related Issue

- close #45 

## 📝 Summary

- 취득, 취득 예정에 대한 중복 제약 조건 추가
- CertificationType 추가
- Icon, CardType 랜덤 발급 로직 추가
- UserPreCertificationRepository 쿼리 수정
- 
## 🙏 Question & PR point

- API 명세서 변경 필요(취득 예정)

## 📬 Postman



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 자격증 생성 시 자격증 종류(CertificationType) 필드 추가 및 처리 지원.
  * 카드 타입(CardType) 및 아이콘 타입(IconType) 순차 발급 로직 도입.
  * 각 카드 타입에 이미지 URL 및 인덱스 추가, 다음 카드/아이콘 타입 발급 메서드 제공.
  * 프리자격증(PreCertification) 응답에 아이콘 이미지 URL 포함.

* **버그 수정**
  * 자격증 및 프리자격증 중복 등록 방지를 위한 DB 유니크 제약조건 추가.

* **테스트**
  * 프리자격증 서비스의 아이콘 타입 순차 발급 로직 검증 테스트 추가.

* **기타**
  * API 경로 및 컨트롤러 클래스명 일부 변경.
  * 에러 코드(존재하지 않는 자격증 종류) 추가.
  * 일부 불필요한 의존성 및 코드 정리.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->