### PR TITLE
#67 [fix] QA 반영

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
@@ -18,6 +18,7 @@ import org.sopt.certi_server.global.error.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -63,6 +64,7 @@ public class CertificationService {
                 .charge(request.charge())
                 .description(request.description())
                 .testDateInformation(request.testDateInformation())
+                .nearestTestDate(LocalDate.parse(request.nearestTestDate()))
                 .applicationMethod(request.applicationMethod())
                 .applicationUrl(request.applicationUrl())
                 .build();

--- a/src/main/java/org/sopt/certi_server/domain/favorite/dto/response/FavoriteCertificationSimple.java
+++ b/src/main/java/org/sopt/certi_server/domain/favorite/dto/response/FavoriteCertificationSimple.java
@@ -3,9 +3,9 @@ package org.sopt.certi_server.domain.favorite.dto.response;
 import org.sopt.certi_server.domain.certification.entity.Certification;
 import org.sopt.certi_server.domain.certification.entity.enums.TestType;
 
-public record FavoriteCertificationSimple(Long certificationId, String certificationName, String testType, String agencyName) {
+public record FavoriteCertificationSimple(Long certificationId, boolean isFavorite, String certificationName, String testType, String agencyName) {
 
     public static FavoriteCertificationSimple from(Certification certification){
-        return new FavoriteCertificationSimple(certification.getId(), certification.getName(), certification.getTestType().getType(), certification.getAgency().getName());
+        return new FavoriteCertificationSimple(certification.getId(), true, certification.getName(), certification.getTestType().getType(), certification.getAgency().getName());
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/favorite/dto/response/FavoriteCertificationSimple.java
+++ b/src/main/java/org/sopt/certi_server/domain/favorite/dto/response/FavoriteCertificationSimple.java
@@ -3,9 +3,9 @@ package org.sopt.certi_server.domain.favorite.dto.response;
 import org.sopt.certi_server.domain.certification.entity.Certification;
 import org.sopt.certi_server.domain.certification.entity.enums.TestType;
 
-public record FavoriteCertificationSimple(Long certificationId, boolean isFavorite, String certificationName, String testType, String agencyName) {
+public record FavoriteCertificationSimple(Long certificationId, boolean isFavorite, String certificationName, String certificationType, String testType, String agencyName) {
 
     public static FavoriteCertificationSimple from(Certification certification){
-        return new FavoriteCertificationSimple(certification.getId(), true, certification.getName(), certification.getTestType().getType(), certification.getAgency().getName());
+        return new FavoriteCertificationSimple(certification.getId(), true, certification.getName(), certification.getCertificationType().getKoreanName(), certification.getTestType().getType(), certification.getAgency().getName());
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/response/AuthResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/response/AuthResponse.java
@@ -5,16 +5,17 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record AuthResponse(
         Long userId,
+        String nickName,
         boolean needSignUp,
         String preSignupToken,
         JwtResponse tokenResponse,
         OAuthUserInformation userInformation
 ) {
     public static AuthResponse ofNotRegisteredUser(String preSignupToken, OAuthUserInformation information){
-        return new AuthResponse(null, true, preSignupToken, null, information);
+        return new AuthResponse(null, null, true, preSignupToken, null, information);
     }
 
-    public static AuthResponse ofRegisteredUser(Long userId, JwtResponse token){
-        return new AuthResponse(userId, false, null, token, null);
+    public static AuthResponse ofRegisteredUser(Long userId, String nickName, JwtResponse token){
+        return new AuthResponse(userId, nickName, false, null, token, null);
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/entity/UserMajorImpl.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/entity/UserMajorImpl.java
@@ -1,5 +1,7 @@
 package org.sopt.certi_server.domain.user.entity;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.sopt.certi_server.domain.major.entity.MajorImpl;
 
 import jakarta.persistence.Entity;
@@ -15,6 +17,7 @@ import lombok.Getter;
 @Getter
 @Entity
 @Table(name = "user_major_impl")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserMajorImpl {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,4 +30,13 @@ public class UserMajorImpl {
 	@ManyToOne(fetch = FetchType.LAZY, targetEntity = MajorImpl.class)
 	@JoinColumn(name = "major_impl_id")
 	private MajorImpl majorImpl;
+
+	public UserMajorImpl(User user, MajorImpl major) {
+		this.user = user;
+		this.majorImpl = major;
+	}
+
+	public static UserMajorImpl createUserMajorImpl(User user, MajorImpl major){
+		return new UserMajorImpl(user, major);
+	}
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/service/AuthService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/AuthService.java
@@ -18,9 +18,11 @@ import org.sopt.certi_server.domain.user.dto.response.JwtResponse;
 import org.sopt.certi_server.domain.user.dto.response.OAuthUserInformation;
 import org.sopt.certi_server.domain.user.entity.User;
 import org.sopt.certi_server.domain.user.entity.UserJob;
+import org.sopt.certi_server.domain.user.entity.UserMajorImpl;
 import org.sopt.certi_server.domain.user.entity.enums.SocialType;
 import org.sopt.certi_server.domain.user.entity.enums.TrackType;
 import org.sopt.certi_server.domain.user.repository.UserJobRepository;
+import org.sopt.certi_server.domain.user.repository.UserMajorImplRepository;
 import org.sopt.certi_server.domain.user.repository.UserRepository;
 import org.sopt.certi_server.global.error.code.ErrorCode;
 import org.sopt.certi_server.global.error.exception.NotFoundException;
@@ -39,6 +41,7 @@ public class AuthService {
     private final JobRepository jobRepository;
     private final UserJobRepository userJobRepository;
     private final MajorImplRepository majorImplRepository;
+    private final UserMajorImplRepository userMajorImplRepository;
     private final JwtService jwtService;
     private final KakaoService kakaoService;
 
@@ -73,6 +76,11 @@ public class AuthService {
                             .orElseThrow(() -> new NotFoundException(ErrorCode.JOB_NOT_FOUND));
                     userJobRepository.save(UserJob.createUserJob(newUser, job));
                 });
+
+        MajorImpl major = majorImplRepository.findMajorImplByName(request.major())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.MAJOR_NOT_FOUND));
+
+        userMajorImplRepository.save(UserMajorImpl.createUserMajorImpl(newUser, major));
 
         JwtResponse token = jwtService.issueToken(newUser.getId());
         return AuthResponse.ofRegisteredUser(newUser.getId(), newUser.getNickname(), token);

--- a/src/main/java/org/sopt/certi_server/domain/user/service/AuthService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/AuthService.java
@@ -55,7 +55,7 @@ public class AuthService {
 
     private AuthResponse handleExistingUser(User user) {
         JwtResponse jwtResponse = jwtService.issueToken(user.getId());
-        return AuthResponse.ofRegisteredUser(user.getId(), jwtResponse);
+        return AuthResponse.ofRegisteredUser(user.getId(), user.getNickname(), jwtResponse);
     }
 
     @Transactional
@@ -75,7 +75,7 @@ public class AuthService {
                 });
 
         JwtResponse token = jwtService.issueToken(newUser.getId());
-        return AuthResponse.ofRegisteredUser(newUser.getId(), token);
+        return AuthResponse.ofRegisteredUser(newUser.getId(), newUser.getNickname(), token);
     }
 
     public JwtResponse reIssueToken(String authorization) {

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/controller/UserPreCertificationController.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/controller/UserPreCertificationController.java
@@ -26,12 +26,12 @@ public class UserPreCertificationController {
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, userPreCertificationService.getPreCertificationListDataByUserId(userId)));
     }
 
-    @PostMapping("/{pre-certificationId}")
+    @PostMapping("/{certificationId}")
     public ResponseEntity<SuccessResponse<Void>> addPreCertification(
             @AuthenticationPrincipal @NotNull(message = "인증되지 않은 사용자입니다.") Long userId,
-            @PathVariable(name = "pre-certificationId") Long preCertificationId
+            @PathVariable(name = "certificationId") Long certificationId
     ){
-        userPreCertificationService.createNewPreCertification(userId, preCertificationId);
+        userPreCertificationService.createNewPreCertification(userId, certificationId);
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
     }
 

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/dto/response/PreCertificationSimple.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/dto/response/PreCertificationSimple.java
@@ -1,17 +1,20 @@
 package org.sopt.certi_server.domain.userprecertification.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import org.sopt.certi_server.domain.userprecertification.entity.UserPreCertification;
+
+import java.time.LocalDate;
 
 public record PreCertificationSimple(
         Long certificationId,
         String certificationName,
         String averagePeriod,
-        String testDate,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul") LocalDate nearestTestDate,
         String agencyName,
-        String iconImageUrl
+        int iconIndex
 ) {
 
     public static PreCertificationSimple from(UserPreCertification upc){
-        return new PreCertificationSimple(upc.getCertification().getId(), upc.getCertification().getName(), upc.getCertification().getAveragePeriod(),upc.getCertification().getTestDateInformation(), upc.getCertification().getAgency().getName(), upc.getIconType().getIconImageUrl());
+        return new PreCertificationSimple(upc.getCertification().getId(), upc.getCertification().getName(), upc.getCertification().getAveragePeriod(),upc.getCertification().getNearestTestDate(), upc.getCertification().getAgency().getName(), upc.getIconType().getIndex());
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/service/UserPreCertificationService.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/service/UserPreCertificationService.java
@@ -36,9 +36,9 @@ public class UserPreCertificationService {
     }
 
     @Transactional
-    public void createNewPreCertification(Long userId, Long preCertificationId) {
+    public void createNewPreCertification(Long userId, Long certificationId) {
         User user = userService.getUser(userId);
-        Certification certification = certificationService.getCertification(preCertificationId);
+        Certification certification = certificationService.getCertification(certificationId);
 
         IconType iconType = userPreCertificationRepository.findFirstByUserOrderByCreatedTimeDesc(user)
                 .map(userPreCertification -> IconType.issueNextIconType(userPreCertification.getIconType().getIndex()))

--- a/src/main/java/org/sopt/certi_server/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/certi_server/global/config/SecurityConfig.java
@@ -25,11 +25,7 @@ public class SecurityConfig {
         "/api/v1/auth/login",
         "/api/v1/auth/sign-up",
         "/api/v1/auth/reissue",
-        "/api/v1/careers/**",
-        "/api/v1/activity/**",
-        "/api/v1/prior-certification/**",
-        "/api/v1/home/**",
-        "/api/v1/certification",
+        "/api/v1/admin/**"
     };
 
 

--- a/src/main/java/org/sopt/certi_server/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/certi_server/global/filter/JwtAuthenticationFilter.java
@@ -27,7 +27,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         "/api/v1/auth/login-uri",
         "/api/v1/auth/login",
         "/api/v1/auth/sign-up",
-        "/api/v1/auth/reissue",
+        "/api/v1/auth/reissue"
     );
 
     private final JwtExtractor jwtExtractor;

--- a/src/main/java/org/sopt/certi_server/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/certi_server/global/filter/JwtAuthenticationFilter.java
@@ -28,11 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         "/api/v1/auth/login",
         "/api/v1/auth/sign-up",
         "/api/v1/auth/reissue",
-        "/api/v1/careers/**",
-        "/api/v1/activity/**",
-        "/api/v1/prior-certification/**",
-        "/api/v1/home/**",
-        "/api/v1/certification"
+        "/api/v1/admin/**"
     );
 
     private final JwtExtractor jwtExtractor;


### PR DESCRIPTION
## 📣 Related Issue

- close #67 

## 📝 Summary



## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

- 회원가입 및 로그인 시 사용자 닉네임 반환
![image](https://github.com/user-attachments/assets/9ae12667-1191-4e1f-a4c8-dfe0c0d8f218)

- 취득예정 API QA 반영
![image](https://github.com/user-attachments/assets/bd66e964-a2c5-4993-be6b-53aa393c0964)

- 즐겨찾기 자격증 리스트 API QA 반영
![image](https://github.com/user-attachments/assets/b105f350-2d71-446d-a6a5-e0775784f559)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * 인증 관련 응답에 사용자 닉네임 정보가 추가되어, 로그인 및 회원가입 시 닉네임을 확인할 수 있습니다.
  * 회원가입 시 사용자의 전공 정보를 연동하여 등록할 수 있습니다.
  * 자격증 관련 정보에 시험 예정일(nearestTestDate)이 추가되어 날짜 형식으로 확인할 수 있습니다.
  * 사전 자격증 관련 API 경로 및 변수명이 보다 직관적으로 변경되었습니다.
  * 사전 자격증 간단 응답에 시험 예정일과 아이콘 인덱스 정보가 추가되었습니다.
  * 즐겨찾기 자격증 응답에 즐겨찾기 여부(isFavorite)와 자격증 유형(certificationType) 정보가 포함되었습니다.
  * 일부 API 인증 예외 경로가 관리(Admin) 경로로 통합되어 보안 설정이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->