### PR TITLE
Fix/#74 Acquisition 수정

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/acquisition/dto/response/GetAcquisitionDetailResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/acquisition/dto/response/GetAcquisitionDetailResponse.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 @Builder
 public record GetAcquisitionDetailResponse(
+	Long acquisitionId,
 	String cardFrontImageUrl,
 	String cardBackImageUrl,
 	int index,
@@ -21,6 +22,7 @@ public record GetAcquisitionDetailResponse(
 ) {
 	public static GetAcquisitionDetailResponse from(Acquisition acquisition) {
 		return GetAcquisitionDetailResponse.builder()
+			.acquisitionId(acquisition.getId())
 			.cardFrontImageUrl(acquisition.getCardType().getCardFrontImageUrl())
 			.cardBackImageUrl(acquisition.getCardType().getCardBackImageUrl())
 			.index(acquisition.getCardType().getIndex())

--- a/src/main/java/org/sopt/certi_server/domain/acquisition/dto/response/GetAcquisitionListResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/acquisition/dto/response/GetAcquisitionListResponse.java
@@ -3,7 +3,7 @@ package org.sopt.certi_server.domain.acquisition.dto.response;
 import java.util.List;
 
 public record GetAcquisitionListResponse(
-	List<GetAcquisitionResponse> getPriorCertificaitonResponses
+	List<GetAcquisitionResponse> getAcquisitionResponses
 ) {
 	public static GetAcquisitionListResponse of(List<GetAcquisitionResponse> priorCertificaitonResponses) {
 		return new GetAcquisitionListResponse(priorCertificaitonResponses);

--- a/src/main/java/org/sopt/certi_server/domain/acquisition/dto/response/GetAcquisitionResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/acquisition/dto/response/GetAcquisitionResponse.java
@@ -10,6 +10,8 @@ import java.util.List;
 
 @Builder
 public record GetAcquisitionResponse(
+	Long acquisitionId,
+	int index,
 	String name,
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
 	LocalDate createdAt,
@@ -19,6 +21,8 @@ public record GetAcquisitionResponse(
 ) {
 	public static GetAcquisitionResponse from(Acquisition acquisition) {
 		return GetAcquisitionResponse.builder()
+			.acquisitionId(acquisition.getId())
+			.index(acquisition.getCardType().getIndex())
 			.name(acquisition.getCertification().getName())
 			.createdAt(acquisition.getCreatedTime().toLocalDate())
 			.cardFrontImageUrl(acquisition.getCardType().getCardFrontImageUrl())

--- a/src/main/java/org/sopt/certi_server/domain/acquisition/repository/AcquisitionRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/acquisition/repository/AcquisitionRepository.java
@@ -21,4 +21,6 @@ public interface AcquisitionRepository extends JpaRepository<Acquisition, Long> 
 	Optional<Acquisition> findFirstByUserOrderByCreatedTimeDesc(User user);
 
 	void deleteAllByCertification(Certification certification);
+
+	boolean existsByUserAndCertification(User user, Certification certification);
 }

--- a/src/main/java/org/sopt/certi_server/domain/acquisition/service/AcquisitionService.java
+++ b/src/main/java/org/sopt/certi_server/domain/acquisition/service/AcquisitionService.java
@@ -15,6 +15,7 @@ import org.sopt.certi_server.domain.certification.service.CertificationService;
 import org.sopt.certi_server.domain.user.entity.User;
 import org.sopt.certi_server.domain.user.service.UserService;
 import org.sopt.certi_server.global.error.code.ErrorCode;
+import org.sopt.certi_server.global.error.exception.BadRequestException;
 import org.sopt.certi_server.global.error.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,6 +41,11 @@ public class AcquisitionService {
 		log.info("userId : ", userId);
 		Certification certification = certificationService.getCertification(certificationId);
 		User user = userService.getUser(userId);
+
+		//중복 여부 확인
+		if(acquisitionRepository.existsByUserAndCertification(user, certification)){
+			throw new BadRequestException(ErrorCode.DUPLICATED_ACQUISITION);
+		}
 
 		CardType cardType = acquisitionRepository.findFirstByUserOrderByCreatedTimeDesc(user)
 				.map(acquisition -> {
@@ -76,8 +82,8 @@ public class AcquisitionService {
 
 	public List<GetAcquisitionResponse> getAcquisitionList(final Long userId) {
 		User user = userService.getUser(userId);
-		List<Acquisition> userPriorCertificationList = acquisitionRepository.findByUserOrderByIdAsc(user);
-		List<GetAcquisitionResponse> responses = userPriorCertificationList.stream()
+		List<Acquisition> acquisitionList = acquisitionRepository.findByUserOrderByIdAsc(user);
+		List<GetAcquisitionResponse> responses = acquisitionList.stream()
 			.map(GetAcquisitionResponse::from)
 			.toList();
 

--- a/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
+++ b/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
 	/* 409 CONFLICT */
 
 	DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "E409001", "리소스 중복입니다"),
+	DUPLICATED_ACQUISITION(HttpStatus.CONFLICT, "E409002", "이미 취득한 자격증입니다"),
 
 	/* 500 INTERNAL SERVER ERROR */
 


### PR DESCRIPTION
## 📣 Related Issue

- close #74 

## 📝 Summary

- 이미 등록된 취득한 자격증일 경우의 에러 메세지를 커스텀하였습니다
- 취득한 자격증 리스트 조회 시 id값과 index값을 dto에 추가해주었습니다


## 📬 Postman

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/b1d283b5-9247-4256-99c3-b270d0aac019" />
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/0cdba2e2-4b97-4258-a4d5-52edc27cf5cd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 자격증 취득 시, 이미 취득한 자격증에 대해 중복 등록을 방지하고 안내 메시지를 제공합니다.

* **버그 수정**
  * 자격증 상세 및 목록 조회 응답에 자격증 ID와 인덱스 정보가 추가되어 더 정확한 정보를 제공합니다.

* **문서화**
  * 중복 취득 시 반환되는 에러 메시지 및 코드가 명확하게 추가되었습니다.

* **스타일**
  * 일부 변수명이 더 직관적으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->