### PR TITLE
#75 [fix] 온보딩 요구사항 변경에 따른 API 수정

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/user/controller/AuthController.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/controller/AuthController.java
@@ -6,10 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.certi_server.domain.user.dto.request.LoginRequest;
 import org.sopt.certi_server.domain.user.dto.request.LoginUriRequest;
 import org.sopt.certi_server.domain.user.dto.request.SignupRequest;
-import org.sopt.certi_server.domain.user.dto.response.AuthResponse;
-import org.sopt.certi_server.domain.user.dto.response.JwtResponse;
-import org.sopt.certi_server.domain.user.dto.response.LoginUriResponse;
-import org.sopt.certi_server.domain.user.dto.response.OAuthUserInformation;
+import org.sopt.certi_server.domain.user.dto.response.*;
 import org.sopt.certi_server.domain.user.entity.enums.SocialType;
 import org.sopt.certi_server.domain.user.service.AuthService;
 import org.sopt.certi_server.domain.user.service.SocialService;
@@ -47,7 +44,7 @@ public class AuthController {
     }
 
     @PostMapping(value = "/sign-up")
-    public ResponseEntity<SuccessResponse<AuthResponse>> processSignup(
+    public ResponseEntity<SuccessResponse<SignUpResponse>> processSignup(
             @RequestHeader("Authorization") @NotEmpty(message = "임시 토큰이 누락되었습니다.") String authorization,
             @Valid @RequestBody SignupRequest request
     ){

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/response/SignUpResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/response/SignUpResponse.java
@@ -1,0 +1,32 @@
+package org.sopt.certi_server.domain.user.dto.response;
+
+import org.sopt.certi_server.domain.job.entity.Job;
+import org.sopt.certi_server.domain.major.entity.MajorImpl;
+import org.sopt.certi_server.domain.user.entity.User;
+
+import java.util.List;
+
+public record SignUpResponse(
+        Long userId,
+        String nickName,
+        String university,
+        String trackType,
+        String major,
+        List<String> jobs,
+        JwtResponse jwtResponse
+) {
+
+    public static SignUpResponse of(User user, MajorImpl major, List<Job> jobs, JwtResponse jwtResponse){
+        return new SignUpResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getUniversityName(),
+                user.getTrack().getName(),
+                major.getName(),
+                jobs.stream()
+                        .map(Job::getName)
+                        .toList(),
+                jwtResponse
+                );
+    }
+}

--- a/src/main/java/org/sopt/certi_server/domain/user/service/AuthService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/AuthService.java
@@ -16,6 +16,7 @@ import org.sopt.certi_server.domain.user.dto.request.SignupRequest;
 import org.sopt.certi_server.domain.user.dto.response.AuthResponse;
 import org.sopt.certi_server.domain.user.dto.response.JwtResponse;
 import org.sopt.certi_server.domain.user.dto.response.OAuthUserInformation;
+import org.sopt.certi_server.domain.user.dto.response.SignUpResponse;
 import org.sopt.certi_server.domain.user.entity.User;
 import org.sopt.certi_server.domain.user.entity.UserJob;
 import org.sopt.certi_server.domain.user.entity.UserMajorImpl;
@@ -29,6 +30,8 @@ import org.sopt.certi_server.global.error.exception.NotFoundException;
 import org.sopt.certi_server.global.jwt.domain.service.JwtService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Service
@@ -62,7 +65,7 @@ public class AuthService {
     }
 
     @Transactional
-    public AuthResponse register(String authorization, SignupRequest request) {
+    public SignUpResponse register(String authorization, SignupRequest request) {
         log.info(authorization);
         jwtService.validatePreSignupToken(authorization);
 
@@ -70,12 +73,14 @@ public class AuthService {
 
         userRepository.save(newUser);
 
-        request.jobs()
-                .forEach(str -> {
-                    Job job = jobRepository.findByName(str)
+        List<Job> jobs = request.jobs().stream()
+                .map(jobStr -> {
+                    Job job = jobRepository.findByName(jobStr)
                             .orElseThrow(() -> new NotFoundException(ErrorCode.JOB_NOT_FOUND));
                     userJobRepository.save(UserJob.createUserJob(newUser, job));
-                });
+                    return job;
+                })
+                .toList();
 
         MajorImpl major = majorImplRepository.findMajorImplByName(request.major())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.MAJOR_NOT_FOUND));
@@ -83,7 +88,12 @@ public class AuthService {
         userMajorImplRepository.save(UserMajorImpl.createUserMajorImpl(newUser, major));
 
         JwtResponse token = jwtService.issueToken(newUser.getId());
-        return AuthResponse.ofRegisteredUser(newUser.getId(), newUser.getNickname(), token);
+        return SignUpResponse.of(
+                newUser,
+                major,
+                jobs,
+                token
+        );
     }
 
     public JwtResponse reIssueToken(String authorization) {


### PR DESCRIPTION
## 📣 Related Issue

- close #75 

## 📝 Summary

- 로그인과 회원가입 성공에 대한 DTO 분리
- 회원가입 서비스 로직에 전공, 직무에 대한 내용 추가

## 🙏 Question & PR point

- 온보딩 request에 대한 유효성 검증 추가 필요

## 📬 Postman
![image](https://github.com/user-attachments/assets/6bfc69f5-7086-41e3-8f91-dbdb32a281f3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 회원가입 시 반환되는 응답 데이터가 확장되어, 유저 정보(아이디, 닉네임, 대학, 트랙, 전공, 직무 리스트)와 JWT 토큰이 포함됩니다.

* **버그 수정**
  * 회원가입 API의 응답 타입이 변경되어 보다 상세한 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->