### PR TITLE
#78 [fix] 소셜로그인 API 추가(액세스 토큰 버전)

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/user/controller/AuthController.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/controller/AuthController.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import org.sopt.certi_server.domain.user.dto.request.LoginRequest;
 import org.sopt.certi_server.domain.user.dto.request.LoginUriRequest;
+import org.sopt.certi_server.domain.user.dto.request.SignInRequest;
 import org.sopt.certi_server.domain.user.dto.request.SignupRequest;
 import org.sopt.certi_server.domain.user.dto.response.*;
 import org.sopt.certi_server.domain.user.entity.enums.SocialType;
@@ -41,6 +42,16 @@ public class AuthController {
 
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, authService.login(userInfo)));
 
+    }
+
+    @PostMapping(value = "/sign-in")
+    public ResponseEntity<SuccessResponse<AuthResponse>> processSignIn(@Valid @RequestBody SignInRequest request){
+        SocialType socialType = SocialType.from(request.socialType());
+        SocialService socialService = authService.getSocialServiceByType(socialType);
+
+        OAuthUserInformation userInfo = socialService.getUserInfoByAccessToken(request.accessToken());
+
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, authService.login(userInfo)));
     }
 
     @PostMapping(value = "/sign-up")

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/request/SignInRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/request/SignInRequest.java
@@ -1,0 +1,8 @@
+package org.sopt.certi_server.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record SignInRequest(
+        @NotEmpty(message = "액세스 토큰이 필요합니다.") String accessToken,
+        @NotEmpty(message = "socialType을 반드시 지정해주어야 합니다.") String socialType) {
+}

--- a/src/main/java/org/sopt/certi_server/domain/user/service/KakaoService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/KakaoService.java
@@ -42,8 +42,17 @@ public class KakaoService implements SocialService{
         log.info("oauth info: {}", oauth);
         String accessToken = oauth.accessToken();
         log.info("kakao oauth access token: {}", accessToken);
+
+        return getUserInfoByAccessToken(accessToken);
+
+    }
+
+    @Override
+    public OAuthUserInformation getUserInfoByAccessToken(String accessToken) {
         try{
             KakaoUserInformationResponse information = kakaoApiFeignClient.getInformation("Bearer " + accessToken);
+            log.info(information.kakaoAccount().profile().nickname());
+            log.info(information.kakaoAccount().email());
             return OAuthUserInformation.from(information);
         }catch (Exception e){
             log.error("kakao user data 획득 실패: {}", e.getMessage());

--- a/src/main/java/org/sopt/certi_server/domain/user/service/SocialService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/SocialService.java
@@ -7,4 +7,6 @@ public interface SocialService {
     public LoginUriResponse getAuthorizationUri();
 
     public OAuthUserInformation getUserInfo(String code);
+
+    public OAuthUserInformation getUserInfoByAccessToken(String token);
 }

--- a/src/main/java/org/sopt/certi_server/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/certi_server/global/config/SecurityConfig.java
@@ -25,6 +25,7 @@ public class SecurityConfig {
         "/api/v1/auth/login-uri",
         "/api/v1/auth/login",
         "/api/v1/auth/sign-up",
+        "/api/v1/auth/sign-in",
         "/api/v1/auth/reissue"
     };
 

--- a/src/main/java/org/sopt/certi_server/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/certi_server/global/filter/JwtAuthenticationFilter.java
@@ -27,6 +27,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         "/api/v1/auth/login-uri",
         "/api/v1/auth/login",
         "/api/v1/auth/sign-up",
+        "/api/v1/auth/sign-in",
         "/api/v1/auth/reissue"
     );
 


### PR DESCRIPTION
## 📣 Related Issue

- close #78 

## 📝 Summary

기존 인가 코드 방식의 로그인 -> 액세스 토큰을 직-접 받아 로그인 처리하는 api 구현

## 🙏 Question & PR point

- N/A

## 📬 Postman

![image](https://github.com/user-attachments/assets/aa2ca1a4-9835-4ac0-a090-a1ac67d27af1)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 소셜 액세스 토큰을 이용한 새로운 로그인 엔드포인트(`/sign-in`)가 추가되었습니다.

* **버그 수정**
  * `/sign-in` 경로가 인증 없이 접근 가능하도록 보안 설정 및 JWT 인증 필터 예외 목록에 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->