### PR TITLE
#85 [feat] 데이터 삽입용 API 제작

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/admin/controller/AdminController.java
+++ b/src/main/java/org/sopt/certi_server/domain/admin/controller/AdminController.java
@@ -1,7 +1,6 @@
 package org.sopt.certi_server.domain.admin.controller;
 
-import org.sopt.certi_server.domain.admin.dto.request.CreateJobRequest;
-import org.sopt.certi_server.domain.admin.dto.request.CreateMajorRequest;
+import org.sopt.certi_server.domain.admin.dto.request.*;
 import org.sopt.certi_server.domain.admin.dto.response.AdminCertificationDetailResponse;
 import org.sopt.certi_server.domain.admin.dto.response.AdminCertificationListResponse;
 import org.sopt.certi_server.domain.admin.service.AdminService;
@@ -32,6 +31,36 @@ public class AdminController {
         certificationService.createCertification(request);
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
     }
+
+	@PostMapping(value = "/major")
+	public ResponseEntity<SuccessResponse<Void>> addMajor(@RequestBody MajorCreateRequest request){
+		adminService.addMajor(request);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+	}
+
+	@PostMapping(value = "/major-impl")
+	public ResponseEntity<SuccessResponse<Void>> addMajorImpl(@RequestBody MajorImplCreateRequest request){
+		adminService.addMajorImpl(request);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+	}
+
+	@PostMapping(value = "/certification-major")
+	public ResponseEntity<SuccessResponse<Void>> addCertificationMajor(@RequestBody CertificationMajorCreateRequest request){
+		adminService.addCertificationMajor(request);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+	}
+
+	@PostMapping(value = "/job")
+	public ResponseEntity<SuccessResponse<Void>> addJob(@RequestBody JobCreateRequest request){
+		adminService.addJob(request);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+	}
+
+	@PostMapping(value = "/certification-job")
+	public ResponseEntity<SuccessResponse<Void>> addCertificationJob(@RequestBody CertificationJobCreateRequest request){
+		adminService.addCertificationJob(request);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+	}
 
     @GetMapping(value = "/certification/{certificationId}")
     public ResponseEntity<SuccessResponse<AdminCertificationDetailResponse>> getCertificationDetail(@PathVariable Long certificationId){

--- a/src/main/java/org/sopt/certi_server/domain/admin/dto/request/CertificationJobCreateRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/admin/dto/request/CertificationJobCreateRequest.java
@@ -1,0 +1,4 @@
+package org.sopt.certi_server.domain.admin.dto.request;
+
+public record CertificationJobCreateRequest(String certificationName, String jobName, float weight) {
+}

--- a/src/main/java/org/sopt/certi_server/domain/admin/dto/request/CertificationMajorCreateRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/admin/dto/request/CertificationMajorCreateRequest.java
@@ -1,0 +1,4 @@
+package org.sopt.certi_server.domain.admin.dto.request;
+
+public record CertificationMajorCreateRequest(String certificationName, String majorName, float weight) {
+}

--- a/src/main/java/org/sopt/certi_server/domain/admin/dto/request/JobCreateRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/admin/dto/request/JobCreateRequest.java
@@ -1,0 +1,4 @@
+package org.sopt.certi_server.domain.admin.dto.request;
+
+public record JobCreateRequest(String jobName) {
+}

--- a/src/main/java/org/sopt/certi_server/domain/admin/dto/request/MajorCreateRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/admin/dto/request/MajorCreateRequest.java
@@ -1,0 +1,4 @@
+package org.sopt.certi_server.domain.admin.dto.request;
+
+public record MajorCreateRequest(String majorName) {
+}

--- a/src/main/java/org/sopt/certi_server/domain/admin/dto/request/MajorImplCreateRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/admin/dto/request/MajorImplCreateRequest.java
@@ -1,0 +1,4 @@
+package org.sopt.certi_server.domain.admin.dto.request;
+
+public record MajorImplCreateRequest(String majorImplName, String majorName) {
+}

--- a/src/main/java/org/sopt/certi_server/domain/admin/service/AdminService.java
+++ b/src/main/java/org/sopt/certi_server/domain/admin/service/AdminService.java
@@ -1,7 +1,7 @@
 package org.sopt.certi_server.domain.admin.service;
 
-import org.sopt.certi_server.domain.admin.dto.request.CreateJobRequest;
-import org.sopt.certi_server.domain.admin.dto.request.CreateMajorRequest;
+import org.sopt.certi_server.domain.admin.dto.request.CertificationMajorCreateRequest;
+import org.sopt.certi_server.domain.admin.dto.request.*;
 import lombok.RequiredArgsConstructor;
 import org.sopt.certi_server.domain.acquisition.repository.AcquisitionRepository;
 import org.sopt.certi_server.domain.admin.dto.response.*;
@@ -12,6 +12,9 @@ import org.sopt.certi_server.domain.certification.repository.CertificationJobRep
 import org.sopt.certi_server.domain.certification.repository.CertificationMajorRepository;
 import org.sopt.certi_server.domain.certification.repository.CertificationRepository;
 import org.sopt.certi_server.domain.favorite.repository.FavoriteRepository;
+import org.sopt.certi_server.domain.major.entity.MajorImpl;
+import org.sopt.certi_server.domain.major.repository.MajorImplRepository;
+import org.sopt.certi_server.domain.major.repository.MajorRepository;
 import org.sopt.certi_server.domain.userprecertification.repository.UserPreCertificationRepository;
 import org.sopt.certi_server.domain.admin.repository.AdminRepository;
 import org.sopt.certi_server.domain.certification.service.CertificationService;
@@ -22,6 +25,7 @@ import org.sopt.certi_server.domain.major.service.MajorService;
 import org.sopt.certi_server.global.error.code.ErrorCode;
 import org.sopt.certi_server.global.error.exception.InvalidValueException;
 import org.sopt.certi_server.global.error.exception.NotFoundException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +46,8 @@ public class AdminService {
     private final AcquisitionRepository acquisitionRepository;
     private final FavoriteRepository favoriteRepository;
     private final UserPreCertificationRepository userPreCertificationRepository;
+	private final MajorRepository majorRepository;
+	private final MajorImplRepository majorImplRepository;
 
 	@Transactional
 	public void createMajor(Long certificationId, CreateMajorRequest request) {
@@ -53,7 +59,7 @@ public class AdminService {
 			throw new InvalidValueException(ErrorCode.BAD_REQUEST_DATA);
 		}
 
-		CertificationMajor certificationMajor = new CertificationMajor(major, certification, request.weight());
+		CertificationMajor certificationMajor = new CertificationMajor(certification, major, request.weight());
 		certificationMajorRepository.save(certificationMajor);
 	}
 
@@ -73,7 +79,7 @@ public class AdminService {
 		if(certificationJobRepository.findByCertificationAndJob(certification, job).isPresent()){
 			throw new InvalidValueException(ErrorCode.BAD_REQUEST_DATA);
 		}
-		CertificationJob certificationJob = new CertificationJob(job, certification, createJobRequest.weight());
+		CertificationJob certificationJob = new CertificationJob(certification, job, createJobRequest.weight());
 		certificationJobRepository.save(certificationJob);
 	}
 
@@ -130,4 +136,63 @@ public class AdminService {
 
         certificationRepository.delete(certification);
     }
+
+	@Transactional
+	public void addMajor(MajorCreateRequest request) {
+		try{
+			majorRepository.save(Major.create(request.majorName()));
+		}catch (DataIntegrityViolationException e){
+			throw new DataIntegrityViolationException("이미 존재하는 중분류 학과입니다. \n" + e);
+		}
+	}
+
+	@Transactional
+	public void addMajorImpl(MajorImplCreateRequest request){
+		Major major = majorRepository.findByName(request.majorName())
+				.orElseThrow(() -> new NotFoundException(ErrorCode.MAJOR_NOT_FOUND));
+		try{
+			majorImplRepository.save(MajorImpl.create(major, request.majorImplName()));
+		}catch (DataIntegrityViolationException e){
+			throw new DataIntegrityViolationException("이미 존재하는 세부 학과입니다. \n" + e);
+		}
+	}
+
+	@Transactional
+	public void addCertificationMajor(CertificationMajorCreateRequest request) {
+
+		Major major = majorRepository.findByName(request.majorName())
+				.orElseThrow(() -> new NotFoundException(ErrorCode.MAJOR_NOT_FOUND));
+		Certification certification = certificationRepository.findByName(request.certificationName())
+				.orElseThrow(() -> new NotFoundException(ErrorCode.CERTIFICATION_NOT_FOUND));
+
+		try{
+			certificationMajorRepository.save(CertificationMajor.create(certification, major, request.weight()));
+		}catch (DataIntegrityViolationException e){
+			throw new DataIntegrityViolationException("이미 존재하는 (자격증 - 학과) 가중치 매핑입니다. \n" + e);
+		}
+	}
+
+	@Transactional
+	public void addJob(JobCreateRequest request) {
+		try{
+			jobRepository.save(Job.create(request.jobName()));
+		}catch (DataIntegrityViolationException e){
+			throw new DataIntegrityViolationException("이미 존재하는 직무입니다. \n" + e);
+		}
+	}
+
+	@Transactional
+	public void addCertificationJob(CertificationJobCreateRequest request){
+
+		Job job = jobRepository.findByName(request.jobName())
+				.orElseThrow(() -> new NotFoundException(ErrorCode.JOB_NOT_FOUND));
+		Certification certification = certificationRepository.findByName(request.certificationName())
+				.orElseThrow(() -> new NotFoundException(ErrorCode.CERTIFICATION_NOT_FOUND));
+
+		try{
+			certificationJobRepository.save(CertificationJob.create(certification, job, request.weight()));
+		}catch (DataIntegrityViolationException e){
+			throw new DataIntegrityViolationException("이미 존재하는 (자격증 - 직무) 가중치 매핑입니다. \n" + e);
+		}
+	}
 }

--- a/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationSimple.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationSimple.java
@@ -1,5 +1,6 @@
 package org.sopt.certi_server.domain.certification.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import org.sopt.certi_server.domain.certification.entity.Certification;
 
@@ -13,17 +14,18 @@ public class CertificationSimple{
     private String certificationType;
     private String testType;
     private List<String> tags;
-    private boolean isFavorite;
+    @JsonProperty(value = "isFavorite")
+    private boolean favorite;
 
     public CertificationSimple(
             Certification certification,
-            boolean isFavorite
+            boolean favorite
     ){
         this.certificationId = certification.getId();
         this.certificationName = certification.getName();
         this.certificationType = certification.getCertificationType().getKoreanName();
         this.testType = certification.getTestType().getType();
         this.tags = certification.getTags();
-        this.isFavorite = isFavorite;
+        this.favorite = favorite;
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/certification/entity/CertificationJob.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/entity/CertificationJob.java
@@ -10,7 +10,12 @@ import org.sopt.certi_server.domain.major.entity.Major;
 
 @Entity
 @Getter
-@Table(name = "certification_job")
+@Table(
+        name = "certification_job",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"certification_id", "job_id"})
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CertificationJob {
 
@@ -29,12 +34,16 @@ public class CertificationJob {
 
     private float weight;
 
+    public static CertificationJob create(Certification certification, Job job, float weight) {
+        return new CertificationJob(certification, job, weight);
+    }
+
     public void updateJob(Job job) {
         this.job = job;
     }
 
     @Builder
-    public CertificationJob(Job job, Certification certification, float weight) {
+    public CertificationJob(Certification certification, Job job, float weight) {
         this.job = job;
         this.certification = certification;
         this.weight = weight;

--- a/src/main/java/org/sopt/certi_server/domain/certification/entity/CertificationMajor.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/entity/CertificationMajor.java
@@ -10,7 +10,13 @@ import org.sopt.certi_server.domain.major.entity.Major;
 
 @Entity
 @Getter
-@Table(name = "certification_major")
+@Table(
+        name = "certification_major",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"certification_id", "major_id"})
+        }
+)
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CertificationMajor {
 
@@ -28,11 +34,15 @@ public class CertificationMajor {
 
     private float weight;
 
+    public static CertificationMajor create(Certification certification, Major major, float weight) {
+        return new CertificationMajor(certification, major, weight);
+    }
+
     public void updateMajor(Major major) {
         this.major = major;
     }
 
-    public CertificationMajor(Major major, Certification certification, float weight) {
+    public CertificationMajor(Certification certification, Major major, float weight) {
         this.major = major;
         this.certification = certification;
         this.weight = weight;

--- a/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CertificationRepository extends JpaRepository<Certification, Long> {
@@ -26,4 +27,6 @@ public interface CertificationRepository extends JpaRepository<Certification, Lo
        where c.name like concat('%', :keyword, '%') 
 """)
     List<CertificationSimple> searchByKeyword(User user, String keyword);
+
+    Optional<Certification> findByName(String certificationName);
 }

--- a/src/main/java/org/sopt/certi_server/domain/job/entity/Job.java
+++ b/src/main/java/org/sopt/certi_server/domain/job/entity/Job.java
@@ -25,7 +25,14 @@ public class Job {
 	@Column(name = "job_id", nullable = false)
 	private Long id;
 
-	@Column(name = "name", nullable = false)
+	@Column(name = "name", nullable = false, unique = true)
 	private String name;
 
+	public Job(String jobName) {
+		this.name = jobName;
+	}
+
+	public static Job create(String jobName) {
+		return new Job(jobName);
+	}
 }

--- a/src/main/java/org/sopt/certi_server/domain/major/entity/Major.java
+++ b/src/main/java/org/sopt/certi_server/domain/major/entity/Major.java
@@ -20,6 +20,14 @@ public class Major {
 	@Column(name = "major_id", nullable = false)
 	private Long id;
 
-	@Column(nullable = false)
+	@Column(nullable = false, unique = true)
 	private String name;
+
+	public Major(String majorName) {
+		this.name = majorName;
+	}
+
+	public static Major create(String majorName){
+		return new Major(majorName);
+	}
 }

--- a/src/main/java/org/sopt/certi_server/domain/major/entity/MajorImpl.java
+++ b/src/main/java/org/sopt/certi_server/domain/major/entity/MajorImpl.java
@@ -15,10 +15,19 @@ public class MajorImpl {
     @Column(name = "major_impl_id", nullable = false)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "major_id")
     private Major major;
+
+    public MajorImpl(Major major, String majorImplName) {
+        this.major = major;
+        this.name = majorImplName;
+    }
+
+    public static MajorImpl create(Major major, String majorImplName) {
+        return new MajorImpl(major, majorImplName);
+    }
 }


### PR DESCRIPTION
## 📣 Related Issue

- close #85 

## 📝 Summary

- 직무, 학과(세부, 중분류), 자격증 - 직무, 자격증 - 학과 데이터 등록 api 추가

## 🙏 Question & PR point

- 데이터 삽입용 API입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 전공, 세부전공, 직업, 자격증-전공/직업 매핑을 추가할 수 있는 관리용 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 자격증 요약 응답에서 즐겨찾기 필드명이 일관성 있게 변경되어, 외부 응답에서는 기존과 동일하게 동작합니다.

* **개선 사항**
  * 전공, 세부전공, 직업, 자격증-전공/직업 매핑의 중복 등록 및 데이터 무결성이 강화되었습니다.
  * 엔터티 생성 시 정적 팩토리 메서드가 도입되어 코드 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->