### PR TITLE
Feat/#84 카테고리별 자격증 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,11 +53,38 @@ dependencies {
 	implementation("software.amazon.awssdk:bom:2.21.0")
 	implementation("software.amazon.awssdk:s3:2.21.0")
 
-	// Feign
+	// Feign 추가
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.3.0'
 
+	//healthcheck 추가
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+	//QueryDsl 추가
+	implementation 'com.querydsl:querydsl-apt:5.0.0'
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	implementation 'com.querydsl:querydsl-core:5.0.0'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+}
+
+// Querydsl 빌드 옵션 설정
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(generated)
 }
 
 tasks.named('test') {

--- a/src/main/java/org/sopt/certi_server/domain/admin/controller/AdminController.java
+++ b/src/main/java/org/sopt/certi_server/domain/admin/controller/AdminController.java
@@ -1,7 +1,6 @@
 package org.sopt.certi_server.domain.admin.controller;
 
-import org.sopt.certi_server.domain.admin.dto.request.CreateJobRequest;
-import org.sopt.certi_server.domain.admin.dto.request.CreateMajorRequest;
+import org.sopt.certi_server.domain.admin.dto.request.*;
 import org.sopt.certi_server.domain.admin.dto.response.AdminCertificationDetailResponse;
 import org.sopt.certi_server.domain.admin.dto.response.AdminCertificationListResponse;
 import org.sopt.certi_server.domain.admin.service.AdminService;
@@ -32,6 +31,36 @@ public class AdminController {
         certificationService.createCertification(request);
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
     }
+
+	@PostMapping(value = "/major")
+	public ResponseEntity<SuccessResponse<Void>> addMajor(@RequestBody MajorCreateRequest request){
+		adminService.addMajor(request);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+	}
+
+	@PostMapping(value = "/major-impl")
+	public ResponseEntity<SuccessResponse<Void>> addMajorImpl(@RequestBody MajorImplCreateRequest request){
+		adminService.addMajorImpl(request);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+	}
+
+	@PostMapping(value = "/certification-major")
+	public ResponseEntity<SuccessResponse<Void>> addCertificationMajor(@RequestBody CertificationMajorCreateRequest request){
+		adminService.addCertificationMajor(request);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+	}
+
+	@PostMapping(value = "/job")
+	public ResponseEntity<SuccessResponse<Void>> addJob(@RequestBody JobCreateRequest request){
+		adminService.addJob(request);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+	}
+
+	@PostMapping(value = "/certification-job")
+	public ResponseEntity<SuccessResponse<Void>> addCertificationJob(@RequestBody CertificationJobCreateRequest request){
+		adminService.addCertificationJob(request);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+	}
 
     @GetMapping(value = "/certification/{certificationId}")
     public ResponseEntity<SuccessResponse<AdminCertificationDetailResponse>> getCertificationDetail(@PathVariable Long certificationId){

--- a/src/main/java/org/sopt/certi_server/domain/admin/dto/request/CertificationJobCreateRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/admin/dto/request/CertificationJobCreateRequest.java
@@ -1,0 +1,4 @@
+package org.sopt.certi_server.domain.admin.dto.request;
+
+public record CertificationJobCreateRequest(String certificationName, String jobName, float weight) {
+}

--- a/src/main/java/org/sopt/certi_server/domain/admin/dto/request/CertificationMajorCreateRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/admin/dto/request/CertificationMajorCreateRequest.java
@@ -1,0 +1,4 @@
+package org.sopt.certi_server.domain.admin.dto.request;
+
+public record CertificationMajorCreateRequest(String certificationName, String majorName, float weight) {
+}

--- a/src/main/java/org/sopt/certi_server/domain/admin/dto/request/JobCreateRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/admin/dto/request/JobCreateRequest.java
@@ -1,0 +1,4 @@
+package org.sopt.certi_server.domain.admin.dto.request;
+
+public record JobCreateRequest(String jobName) {
+}

--- a/src/main/java/org/sopt/certi_server/domain/admin/dto/request/MajorCreateRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/admin/dto/request/MajorCreateRequest.java
@@ -1,0 +1,4 @@
+package org.sopt.certi_server.domain.admin.dto.request;
+
+public record MajorCreateRequest(String majorName) {
+}

--- a/src/main/java/org/sopt/certi_server/domain/admin/dto/request/MajorImplCreateRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/admin/dto/request/MajorImplCreateRequest.java
@@ -1,0 +1,4 @@
+package org.sopt.certi_server.domain.admin.dto.request;
+
+public record MajorImplCreateRequest(String majorImplName, String majorName) {
+}

--- a/src/main/java/org/sopt/certi_server/domain/admin/service/AdminService.java
+++ b/src/main/java/org/sopt/certi_server/domain/admin/service/AdminService.java
@@ -1,7 +1,7 @@
 package org.sopt.certi_server.domain.admin.service;
 
-import org.sopt.certi_server.domain.admin.dto.request.CreateJobRequest;
-import org.sopt.certi_server.domain.admin.dto.request.CreateMajorRequest;
+import org.sopt.certi_server.domain.admin.dto.request.CertificationMajorCreateRequest;
+import org.sopt.certi_server.domain.admin.dto.request.*;
 import lombok.RequiredArgsConstructor;
 import org.sopt.certi_server.domain.acquisition.repository.AcquisitionRepository;
 import org.sopt.certi_server.domain.admin.dto.response.*;
@@ -12,6 +12,9 @@ import org.sopt.certi_server.domain.certification.repository.CertificationJobRep
 import org.sopt.certi_server.domain.certification.repository.CertificationMajorRepository;
 import org.sopt.certi_server.domain.certification.repository.CertificationRepository;
 import org.sopt.certi_server.domain.favorite.repository.FavoriteRepository;
+import org.sopt.certi_server.domain.major.entity.MajorImpl;
+import org.sopt.certi_server.domain.major.repository.MajorImplRepository;
+import org.sopt.certi_server.domain.major.repository.MajorRepository;
 import org.sopt.certi_server.domain.userprecertification.repository.UserPreCertificationRepository;
 import org.sopt.certi_server.domain.admin.repository.AdminRepository;
 import org.sopt.certi_server.domain.certification.service.CertificationService;
@@ -22,6 +25,7 @@ import org.sopt.certi_server.domain.major.service.MajorService;
 import org.sopt.certi_server.global.error.code.ErrorCode;
 import org.sopt.certi_server.global.error.exception.InvalidValueException;
 import org.sopt.certi_server.global.error.exception.NotFoundException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +46,8 @@ public class AdminService {
     private final AcquisitionRepository acquisitionRepository;
     private final FavoriteRepository favoriteRepository;
     private final UserPreCertificationRepository userPreCertificationRepository;
+	private final MajorRepository majorRepository;
+	private final MajorImplRepository majorImplRepository;
 
 	@Transactional
 	public void createMajor(Long certificationId, CreateMajorRequest request) {
@@ -53,7 +59,7 @@ public class AdminService {
 			throw new InvalidValueException(ErrorCode.BAD_REQUEST_DATA);
 		}
 
-		CertificationMajor certificationMajor = new CertificationMajor(major, certification, request.weight());
+		CertificationMajor certificationMajor = new CertificationMajor(certification, major, request.weight());
 		certificationMajorRepository.save(certificationMajor);
 	}
 
@@ -73,7 +79,7 @@ public class AdminService {
 		if(certificationJobRepository.findByCertificationAndJob(certification, job).isPresent()){
 			throw new InvalidValueException(ErrorCode.BAD_REQUEST_DATA);
 		}
-		CertificationJob certificationJob = new CertificationJob(job, certification, createJobRequest.weight());
+		CertificationJob certificationJob = new CertificationJob(certification, job, createJobRequest.weight());
 		certificationJobRepository.save(certificationJob);
 	}
 
@@ -130,4 +136,63 @@ public class AdminService {
 
         certificationRepository.delete(certification);
     }
+
+	@Transactional
+	public void addMajor(MajorCreateRequest request) {
+		try{
+			majorRepository.save(Major.create(request.majorName()));
+		}catch (DataIntegrityViolationException e){
+			throw new DataIntegrityViolationException("이미 존재하는 중분류 학과입니다. \n" + e);
+		}
+	}
+
+	@Transactional
+	public void addMajorImpl(MajorImplCreateRequest request){
+		Major major = majorRepository.findByName(request.majorName())
+				.orElseThrow(() -> new NotFoundException(ErrorCode.MAJOR_NOT_FOUND));
+		try{
+			majorImplRepository.save(MajorImpl.create(major, request.majorImplName()));
+		}catch (DataIntegrityViolationException e){
+			throw new DataIntegrityViolationException("이미 존재하는 세부 학과입니다. \n" + e);
+		}
+	}
+
+	@Transactional
+	public void addCertificationMajor(CertificationMajorCreateRequest request) {
+
+		Major major = majorRepository.findByName(request.majorName())
+				.orElseThrow(() -> new NotFoundException(ErrorCode.MAJOR_NOT_FOUND));
+		Certification certification = certificationRepository.findByName(request.certificationName())
+				.orElseThrow(() -> new NotFoundException(ErrorCode.CERTIFICATION_NOT_FOUND));
+
+		try{
+			certificationMajorRepository.save(CertificationMajor.create(certification, major, request.weight()));
+		}catch (DataIntegrityViolationException e){
+			throw new DataIntegrityViolationException("이미 존재하는 (자격증 - 학과) 가중치 매핑입니다. \n" + e);
+		}
+	}
+
+	@Transactional
+	public void addJob(JobCreateRequest request) {
+		try{
+			jobRepository.save(Job.create(request.jobName()));
+		}catch (DataIntegrityViolationException e){
+			throw new DataIntegrityViolationException("이미 존재하는 직무입니다. \n" + e);
+		}
+	}
+
+	@Transactional
+	public void addCertificationJob(CertificationJobCreateRequest request){
+
+		Job job = jobRepository.findByName(request.jobName())
+				.orElseThrow(() -> new NotFoundException(ErrorCode.JOB_NOT_FOUND));
+		Certification certification = certificationRepository.findByName(request.certificationName())
+				.orElseThrow(() -> new NotFoundException(ErrorCode.CERTIFICATION_NOT_FOUND));
+
+		try{
+			certificationJobRepository.save(CertificationJob.create(certification, job, request.weight()));
+		}catch (DataIntegrityViolationException e){
+			throw new DataIntegrityViolationException("이미 존재하는 (자격증 - 직무) 가중치 매핑입니다. \n" + e);
+		}
+	}
 }

--- a/src/main/java/org/sopt/certi_server/domain/certification/controller/CertificationController.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/controller/CertificationController.java
@@ -1,11 +1,13 @@
 package org.sopt.certi_server.domain.certification.controller;
 
-import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
-import org.sopt.certi_server.domain.admin.dto.response.AdminCertificationListResponse;
+
 import org.sopt.certi_server.domain.certification.dto.request.CertificationCreateRequest;
 import org.sopt.certi_server.domain.certification.dto.response.CertificationDetailResponse;
 import org.sopt.certi_server.domain.certification.dto.response.CertificationListResponse;
+import org.sopt.certi_server.domain.certification.dto.response.CertificationSimple;
 import org.sopt.certi_server.domain.certification.service.CertificationService;
 import org.sopt.certi_server.domain.favorite.service.FavoriteService;
 import org.sopt.certi_server.global.error.code.SuccessCode;
@@ -53,4 +55,16 @@ public class CertificationController {
             return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_DELETE));
         }
     }
+
+
+    @GetMapping
+    public ResponseEntity<SuccessResponse<?>> getCertificationList(
+        @AuthenticationPrincipal Long userId,
+        @RequestParam(value = "isFavorite") Boolean isFavorite,
+        @RequestParam(value = "jobs") String job
+    ){
+        CertificationListResponse certificationListResponse = certificationService.getCertificationList(userId, isFavorite, job);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, certificationListResponse));
+    }
+
 }

--- a/src/main/java/org/sopt/certi_server/domain/certification/dto/request/CertificationCreateRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/dto/request/CertificationCreateRequest.java
@@ -2,6 +2,7 @@ package org.sopt.certi_server.domain.certification.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
@@ -16,7 +17,7 @@ public record CertificationCreateRequest(
         Long charge,
         String description,
         String testDateInformation,
-        @NotEmpty(message = "가장 가까운 시험 날짜를 입력해주세요.")
+        @NotNull(message = "가장 가까운 시험 날짜를 입력해주세요.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
         LocalDate nearestTestDate,
         List<String> tags,

--- a/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationListResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationListResponse.java
@@ -2,9 +2,12 @@ package org.sopt.certi_server.domain.certification.dto.response;
 
 import java.util.List;
 
-public record CertificationListResponse(List<CertificationSimple> certificationSimpleList) {
+public record CertificationListResponse(
+    List<CertificationSimple> certificationSimpleList,
+    int size
+) {
 
     public static CertificationListResponse of(List<CertificationSimple> certificationSimpleList){
-        return new CertificationListResponse(certificationSimpleList);
+        return new CertificationListResponse(certificationSimpleList, certificationSimpleList.size());
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationSimple.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationSimple.java
@@ -6,7 +6,7 @@ import org.sopt.certi_server.domain.certification.entity.Certification;
 import java.util.List;
 
 @Getter
-public class CertificationSimple{
+public class CertificationSimple {
 
     private Long certificationId;
     private String certificationName;
@@ -21,8 +21,10 @@ public class CertificationSimple{
     ){
         this.certificationId = certification.getId();
         this.certificationName = certification.getName();
-        this.certificationType = certification.getCertificationType().getKoreanName();
-        this.testType = certification.getTestType().getType();
+        this.certificationType = certification.getCertificationType() != null ?
+            certification.getCertificationType().getKoreanName() : null;
+        this.testType = certification.getTestType() != null ?
+            certification.getTestType().getType() : null;
         this.tags = certification.getTags();
         this.isFavorite = isFavorite;
     }

--- a/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationSimple.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationSimple.java
@@ -1,5 +1,6 @@
 package org.sopt.certi_server.domain.certification.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import org.sopt.certi_server.domain.certification.entity.Certification;
 
@@ -13,11 +14,12 @@ public class CertificationSimple {
     private String certificationType;
     private String testType;
     private List<String> tags;
-    private boolean isFavorite;
+    @JsonProperty(value = "isFavorite")
+    private boolean favorite;
 
     public CertificationSimple(
             Certification certification,
-            boolean isFavorite
+            boolean favorite
     ){
         this.certificationId = certification.getId();
         this.certificationName = certification.getName();
@@ -26,6 +28,6 @@ public class CertificationSimple {
         this.testType = certification.getTestType() != null ?
             certification.getTestType().getType() : null;
         this.tags = certification.getTags();
-        this.isFavorite = isFavorite;
+        this.favorite = favorite;
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/certification/entity/CertificationJob.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/entity/CertificationJob.java
@@ -10,7 +10,12 @@ import org.sopt.certi_server.domain.major.entity.Major;
 
 @Entity
 @Getter
-@Table(name = "certification_job")
+@Table(
+        name = "certification_job",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"certification_id", "job_id"})
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CertificationJob {
 
@@ -29,12 +34,16 @@ public class CertificationJob {
 
     private float weight;
 
+    public static CertificationJob create(Certification certification, Job job, float weight) {
+        return new CertificationJob(certification, job, weight);
+    }
+
     public void updateJob(Job job) {
         this.job = job;
     }
 
     @Builder
-    public CertificationJob(Job job, Certification certification, float weight) {
+    public CertificationJob(Certification certification, Job job, float weight) {
         this.job = job;
         this.certification = certification;
         this.weight = weight;

--- a/src/main/java/org/sopt/certi_server/domain/certification/entity/CertificationMajor.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/entity/CertificationMajor.java
@@ -10,7 +10,13 @@ import org.sopt.certi_server.domain.major.entity.Major;
 
 @Entity
 @Getter
-@Table(name = "certification_major")
+@Table(
+        name = "certification_major",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"certification_id", "major_id"})
+        }
+)
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CertificationMajor {
 
@@ -28,11 +34,15 @@ public class CertificationMajor {
 
     private float weight;
 
+    public static CertificationMajor create(Certification certification, Major major, float weight) {
+        return new CertificationMajor(certification, major, weight);
+    }
+
     public void updateMajor(Major major) {
         this.major = major;
     }
 
-    public CertificationMajor(Major major, Certification certification, float weight) {
+    public CertificationMajor(Certification certification, Major major, float weight) {
         this.major = major;
         this.certification = certification;
         this.weight = weight;

--- a/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CertificationRepository extends JpaRepository<Certification, Long> {
@@ -26,4 +27,6 @@ public interface CertificationRepository extends JpaRepository<Certification, Lo
        where c.name like concat('%', :keyword, '%') 
 """)
     List<CertificationSimple> searchByKeyword(User user, String keyword);
+
+    Optional<Certification> findByName(String certificationName);
 }

--- a/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationRepositoryCustom.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationRepositoryCustom.java
@@ -29,13 +29,13 @@ public class CertificationRepositoryCustom {
 			.select(certification)
 			.from(certification)
 			.leftJoin(favorite).on(favorite.certification.eq(certification).and(favorite.user.eq(user)))
-			.join(certificationJob).on(certificationJob.certification.eq(certification))
+			.leftJoin(certificationJob).on(certificationJob.certification.eq(certification))
 			.where(certificationJob.job.id.eq(jobId));
 
 		if (isFavorite) {
 			certificationQuery.where(favorite.isNotNull());
 		}else {
-			certificationQuery.where(certification.isNotNull());
+			certificationQuery.where();
 		}
 
 		return certificationQuery.fetch().stream()

--- a/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationRepositoryCustom.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationRepositoryCustom.java
@@ -1,0 +1,48 @@
+package org.sopt.certi_server.domain.certification.repository;
+
+import java.util.List;
+
+import org.sopt.certi_server.domain.certification.dto.response.CertificationSimple;
+import org.sopt.certi_server.domain.certification.entity.Certification;
+import org.sopt.certi_server.domain.certification.entity.QCertification;
+import org.sopt.certi_server.domain.certification.entity.QCertificationJob;
+import org.sopt.certi_server.domain.favorite.entity.QFavorite;
+import org.sopt.certi_server.domain.user.entity.User;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CertificationRepositoryCustom {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public List<CertificationSimple> findByJobAndFavorite(User user, boolean isFavorite, Long jobId) {
+		QCertification certification = QCertification.certification;
+		QFavorite favorite = QFavorite.favorite;
+		QCertificationJob certificationJob = QCertificationJob.certificationJob;
+
+		JPQLQuery<Certification> certificationQuery = jpaQueryFactory
+			.select(certification)
+			.from(certification)
+			.leftJoin(favorite).on(favorite.certification.eq(certification).and(favorite.user.eq(user)))
+			.join(certificationJob).on(certificationJob.certification.eq(certification))
+			.where(certificationJob.job.id.eq(jobId));
+
+		if (isFavorite) {
+			certificationQuery.where(favorite.isNotNull());
+		}else {
+			certificationQuery.where(certification.isNotNull());
+		}
+
+		return certificationQuery.fetch().stream()
+			.map(cert -> new CertificationSimple(
+				cert,
+				isFavorite
+			))
+			.toList();
+	}
+}

--- a/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
@@ -1,6 +1,8 @@
 package org.sopt.certi_server.domain.certification.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.sopt.certi_server.domain.certification.dto.response.CertificationListResponse;
 import org.sopt.certi_server.domain.certification.dto.response.CertificationSimple;
 import org.sopt.certi_server.domain.certification.entity.*;
@@ -10,6 +12,7 @@ import org.sopt.certi_server.domain.certification.dto.request.CertificationCreat
 import org.sopt.certi_server.domain.certification.dto.response.CertificationDetailResponse;
 import org.sopt.certi_server.domain.certification.entity.enums.TestType;
 import org.sopt.certi_server.domain.job.entity.Job;
+import org.sopt.certi_server.domain.job.repository.JobRepository;
 import org.sopt.certi_server.domain.major.entity.Major;
 import org.sopt.certi_server.domain.user.entity.User;
 import org.sopt.certi_server.domain.user.service.UserService;
@@ -18,18 +21,23 @@ import org.sopt.certi_server.global.error.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.util.List;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class CertificationService {
 
     private final CertificationRepository certificationRepository;
     private final AgencyRepository agencyRepository;
     private final CertificationMajorRepository certificationMajorRepository;
     private final UserService userService;
+    private final JobRepository jobRepository;
+    private final CertificationRepositoryCustom certificationRepositoryCustom;
+
 
     public CertificationDetailResponse getCertificationDetail(Long certificationId){
         Certification certification = getCertification(certificationId);
@@ -84,8 +92,23 @@ public class CertificationService {
 
         User user = userService.getUser(userId);
 
-        List<CertificationSimple> certificationSimples = certificationRepository.searchByKeyword(user, keyword);
+        List<CertificationSimple> certificationSimpleRespons = certificationRepository.searchByKeyword(user, keyword);
 
-        return CertificationListResponse.of(certificationSimples);
+        return CertificationListResponse.of(certificationSimpleRespons);
     }
+
+
+    public CertificationListResponse getCertificationList(final Long userId, final boolean isFavorite, final String jobName){
+        log.info("userId : " + userId + " isFavorite : " + isFavorite + " jobName : " + jobName);
+        User user = userService.getUser(userId);
+        Job job = jobRepository.findByName(jobName)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.JOB_NOT_FOUND));
+
+        log.info("job : " + job.getName() + "user" + user.getNickname());
+        List<CertificationSimple> certificationSimpleList = certificationRepositoryCustom.findByJobAndFavorite(user, isFavorite, job.getId());
+
+        return CertificationListResponse.of(certificationSimpleList);
+
+    }
+
 }

--- a/src/main/java/org/sopt/certi_server/domain/job/entity/Job.java
+++ b/src/main/java/org/sopt/certi_server/domain/job/entity/Job.java
@@ -25,7 +25,14 @@ public class Job {
 	@Column(name = "job_id", nullable = false)
 	private Long id;
 
-	@Column(name = "name", nullable = false)
+	@Column(name = "name", nullable = false, unique = true)
 	private String name;
 
+	public Job(String jobName) {
+		this.name = jobName;
+	}
+
+	public static Job create(String jobName) {
+		return new Job(jobName);
+	}
 }

--- a/src/main/java/org/sopt/certi_server/domain/major/entity/Major.java
+++ b/src/main/java/org/sopt/certi_server/domain/major/entity/Major.java
@@ -20,6 +20,14 @@ public class Major {
 	@Column(name = "major_id", nullable = false)
 	private Long id;
 
-	@Column(nullable = false)
+	@Column(nullable = false, unique = true)
 	private String name;
+
+	public Major(String majorName) {
+		this.name = majorName;
+	}
+
+	public static Major create(String majorName){
+		return new Major(majorName);
+	}
 }

--- a/src/main/java/org/sopt/certi_server/domain/major/entity/MajorImpl.java
+++ b/src/main/java/org/sopt/certi_server/domain/major/entity/MajorImpl.java
@@ -15,10 +15,19 @@ public class MajorImpl {
     @Column(name = "major_impl_id", nullable = false)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "major_id")
     private Major major;
+
+    public MajorImpl(Major major, String majorImplName) {
+        this.major = major;
+        this.name = majorImplName;
+    }
+
+    public static MajorImpl create(Major major, String majorImplName) {
+        return new MajorImpl(major, majorImplName);
+    }
 }

--- a/src/main/java/org/sopt/certi_server/global/config/QuerydslConfig.java
+++ b/src/main/java/org/sopt/certi_server/global/config/QuerydslConfig.java
@@ -1,0 +1,21 @@
+package org.sopt.certi_server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
+++ b/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
@@ -37,7 +37,7 @@ public enum ErrorCode {
 	CERTIFICATION_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "E40408", "존재하지 않는 자격증 종류입니다."),
 	CERTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, " E404009", "자격증이 존재하지 않습니다"),
 	AGENCY_NOT_FOUND(HttpStatus.NOT_FOUND, "E404010", "존재하지 않는 인증기관입니다."),
-	CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "E404010", "존재하지 않는 카테고리입니다."),
+	CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "E404011", "존재하지 않는 카테고리입니다."),
 
 
 	/* 409 CONFLICT */


### PR DESCRIPTION
## 📣 Related Issue

- close #84 

## 📝 Summary

- 코드래빗 리뷰 반영
- QueryDSL을 통한 카테고리별 자격증 조회 API

## 📬 Postman

- 즐겨찾기된 자격증 조회

<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/83c9edad-0118-44a3-a898-1980c52074f9" />

- 즐겨찾기 해제된 자격증 조회

<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/36497437-f355-4e91-a682-546108a06dd6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 인증 목록을 직업 및 즐겨찾기 여부로 필터링하여 조회할 수 있는 GET 엔드포인트가 추가되었습니다.
  * 인증 목록 응답에 전체 개수(size) 필드가 포함되었습니다.
  * 관리자용 Major, MajorImpl, CertificationMajor, Job, CertificationJob 추가를 위한 POST 엔드포인트가 새로 도입되었습니다.

* **버그 수정**
  * 인증 생성 요청 시 시험 날짜 유효성 검사가 올바르게 동작하도록 수정되었습니다.
  * 인증 간단 정보 생성 시 null 값 접근으로 인한 오류가 발생하지 않도록 처리되었습니다.

* **개선 및 안정성**
  * 인증 관련 엔티티 및 조인 테이블에 고유 제약 조건이 추가되어 데이터 무결성이 강화되었습니다.
  * 인증, 직업, 전공 관련 엔티티에 생성자 및 정적 팩토리 메서드가 추가되어 객체 생성이 명확해졌습니다.
  * 오류 코드(CATEGORY_NOT_FOUND)가 변경되었습니다.
  * Querydsl 및 관련 빌드 설정이 추가되어 쿼리 성능과 개발 편의성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->