### PR TITLE
#100 [feat] 대학교 검색 API 구현

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/acquisition/controller/AcquisitionController.java
+++ b/src/main/java/org/sopt/certi_server/domain/acquisition/controller/AcquisitionController.java
@@ -1,5 +1,6 @@
 package org.sopt.certi_server.domain.acquisition.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.sopt.certi_server.domain.acquisition.dto.response.GetAcquisitionResponse;
 import org.sopt.certi_server.domain.acquisition.dto.response.GetAcquisitionDetailResponse;
@@ -16,6 +17,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/acquisition")
+@Tag(name = "Acquisition 컨트롤러", description = "취득한 자격증과 관련된 API를 처리합니다.")
 public class AcquisitionController {
 	private final AcquisitionService acquisitionService;
 

--- a/src/main/java/org/sopt/certi_server/domain/activity/controller/ActivityController.java
+++ b/src/main/java/org/sopt/certi_server/domain/activity/controller/ActivityController.java
@@ -19,12 +19,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/activity")
+@Tag(name = "Activity 컨트롤러", description = "대내외 활동과 관련된 API를 처리합니다.")
 public class ActivityController {
 	private final ActivityService activityService;
 

--- a/src/main/java/org/sopt/certi_server/domain/certification/controller/CertificationController.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/controller/CertificationController.java
@@ -2,6 +2,7 @@ package org.sopt.certi_server.domain.certification.controller;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 import org.sopt.certi_server.domain.certification.dto.request.CertificationCreateRequest;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(value = "/api/v1/certification")
+@Tag(name = "Certification 컨트롤러", description = "자격증과 관련된 API를 처리합니다.")
 public class CertificationController {
 
     private final CertificationService certificationService;

--- a/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationDetailResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationDetailResponse.java
@@ -15,7 +15,7 @@ public record CertificationDetailResponse(
         List<String> tags,
         String averagePeriod,
         Long charge,
-        String agency,
+        String agencyName,
         String testType,
         String description,
         String testDateInformation,

--- a/src/main/java/org/sopt/certi_server/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/org/sopt/certi_server/domain/favorite/controller/FavoriteController.java
@@ -1,5 +1,6 @@
 package org.sopt.certi_server.domain.favorite.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.sopt.certi_server.domain.favorite.dto.response.FavoriteCertificationSimpleListResponse;
 import org.sopt.certi_server.domain.favorite.service.FavoriteService;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(value = "/api/v1/home/favorite")
+@Tag(name = "Favorite 컨트롤러", description = "즐겨찾기와 관련된 API를 처리합니다.")
 public class FavoriteController {
 
     private final FavoriteService favoriteService;

--- a/src/main/java/org/sopt/certi_server/domain/major/controller/MajorController.java
+++ b/src/main/java/org/sopt/certi_server/domain/major/controller/MajorController.java
@@ -11,11 +11,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/major")
+@Tag(name = "major 컨트롤러", description = "전공과 관련된 API를 처리합니다.")
 public class MajorController {
 	private final MajorService majorService;
 

--- a/src/main/java/org/sopt/certi_server/domain/user/controller/AuthController.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/controller/AuthController.java
@@ -1,5 +1,6 @@
 package org.sopt.certi_server.domain.user.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
+@Tag(name = "Auth 컨트롤러", description = "로그인과 관련된 API를 처리합니다.")
 public class AuthController {
 
     private final AuthService authService;

--- a/src/main/java/org/sopt/certi_server/domain/user/controller/CareerController.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/controller/CareerController.java
@@ -18,12 +18,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/careers")
+@Tag(name = "Career 컨트롤러", description = "경력사항과 관련된 API를 처리합니다.")
 public class CareerController {
 	private final CareerService careerService;
 

--- a/src/main/java/org/sopt/certi_server/domain/user/controller/UniversityController.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/controller/UniversityController.java
@@ -10,11 +10,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/university")
+@Tag(name = "University 컨트롤러", description = "대학교와 관련된 API를 처리합니다.")
 public class UniversityController {
 	private final UniversityService universityService;
 

--- a/src/main/java/org/sopt/certi_server/domain/user/controller/UniversityController.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/controller/UniversityController.java
@@ -1,0 +1,29 @@
+package org.sopt.certi_server.domain.user.controller;
+
+import org.sopt.certi_server.domain.user.dto.response.GetUniversityListResponse;
+import org.sopt.certi_server.domain.user.service.UniversityService;
+import org.sopt.certi_server.global.error.code.SuccessCode;
+import org.sopt.certi_server.global.error.dto.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/university")
+public class UniversityController {
+	private final UniversityService universityService;
+
+	@GetMapping("/search")
+	public ResponseEntity<SuccessResponse<?>> searchUniversity(
+		@RequestParam(name = "keyword") String keyword
+	){
+		GetUniversityListResponse getUniversityListResponse = universityService.getUniversityList(keyword);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, getUniversityListResponse));
+	}
+
+}

--- a/src/main/java/org/sopt/certi_server/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/controller/UserController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -22,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/user")
 @Slf4j
+@Tag(name = "User 컨트롤러", description = "사용자와 관련된 API를 처리합니다.")
 public class UserController {
 	private final UserService userService;
 

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/response/GetUniversityListResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/response/GetUniversityListResponse.java
@@ -1,0 +1,11 @@
+package org.sopt.certi_server.domain.user.dto.response;
+
+import java.util.List;
+
+public record GetUniversityListResponse(
+	List<String> universityNameList
+) {
+	public static GetUniversityListResponse of(List<String> universityNameList) {
+		return new GetUniversityListResponse(universityNameList);
+	}
+}

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/response/GetUserResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/response/GetUserResponse.java
@@ -16,7 +16,7 @@ public record GetUserResponse(
 	public static GetUserResponse from(User user, MajorImpl majorImpl, int percentage) {
 		return GetUserResponse.builder()
 			.name(user.getNickname())
-			.university(user.getUniversityName())
+			.university(user.getUniversity().getName())
 			.major(majorImpl.getName())
 			.percentage(percentage)
 			.build();

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/response/SignUpResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/response/SignUpResponse.java
@@ -20,7 +20,7 @@ public record SignUpResponse(
         return new SignUpResponse(
                 user.getId(),
                 user.getNickname(),
-                user.getUniversityName(),
+                user.getUniversity().getName(),
                 user.getTrack().getName(),
                 major.getName(),
                 jobs.stream()

--- a/src/main/java/org/sopt/certi_server/domain/user/entity/University.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/entity/University.java
@@ -1,0 +1,25 @@
+package org.sopt.certi_server.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "university")
+public class University {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "university_id")
+	private Long id;
+
+	@Column(name = "name", nullable = false)
+	private String name;
+}

--- a/src/main/java/org/sopt/certi_server/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/entity/User.java
@@ -23,7 +23,7 @@ public class User extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(targetEntity = University.class, fetch = FetchType.LAZY)
-    @JoinColumn(name = "univeirsity_id", nullable = false)
+    @JoinColumn(name = "university_id", nullable = false)
     private University university;
 
     @Column(name = "track")

--- a/src/main/java/org/sopt/certi_server/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/entity/User.java
@@ -22,8 +22,9 @@ public class User extends BaseTimeEntity {
     @Column(name = "user_id")
     private Long id;
 
-    @Column(name = "university_name")
-    private String universityName;
+    @ManyToOne(targetEntity = University.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "univeirsity_id", nullable = false)
+    private University university;
 
     @Column(name = "track")
     @Enumerated(value = EnumType.STRING)
@@ -58,10 +59,10 @@ public class User extends BaseTimeEntity {
     }
 
     @Builder
-    public User(Long id, String universityName, String track, String grade, MajorImpl major, String nickname, String email,
+    public User(Long id, University university, String track, String grade, MajorImpl major, String nickname, String email,
                 String profileImageUrl) {
         this.id = id;
-        this.universityName = universityName;
+        this.university = university;
         this.track = TrackType.from(track);
         this.grade = Grade.from(grade);
         this.major = major;

--- a/src/main/java/org/sopt/certi_server/domain/user/repository/UniversityRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/repository/UniversityRepository.java
@@ -1,0 +1,13 @@
+package org.sopt.certi_server.domain.user.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.sopt.certi_server.domain.user.entity.University;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UniversityRepository extends JpaRepository<University, Long> {
+	List<University> findAllByNameContaining(String name);
+
+	Optional<University> findByName(String name);
+}

--- a/src/main/java/org/sopt/certi_server/domain/user/service/AuthService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/AuthService.java
@@ -47,6 +47,7 @@ public class AuthService {
     private final UserMajorImplRepository userMajorImplRepository;
     private final JwtService jwtService;
     private final KakaoService kakaoService;
+    private final UniversityService universityService;
 
     public AuthResponse login(OAuthUserInformation userInfo){
         return userRepository.findByEmail(userInfo.email())
@@ -121,7 +122,7 @@ public class AuthService {
                 .track(request.track())
                 .grade(request.grade())
                 .major(majorImpl)
-                .universityName(request.university())
+                .university(universityService.getUniversityByName(request.university()))
                 .build();
     }
 

--- a/src/main/java/org/sopt/certi_server/domain/user/service/UniversityService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/UniversityService.java
@@ -1,0 +1,34 @@
+package org.sopt.certi_server.domain.user.service;
+
+import java.util.List;
+
+import org.sopt.certi_server.domain.user.dto.response.GetUniversityListResponse;
+import org.sopt.certi_server.domain.user.entity.University;
+import org.sopt.certi_server.domain.user.repository.UniversityRepository;
+import org.sopt.certi_server.global.error.code.ErrorCode;
+import org.sopt.certi_server.global.error.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UniversityService {
+	private final UniversityRepository universityRepository;
+
+	public GetUniversityListResponse getUniversityList(final String keyword){
+		List<University> universityList = universityRepository.findAllByNameContaining(keyword);
+		List<String> universityNameList = universityList.stream()
+			.map(University::getName)
+			.toList();
+		return GetUniversityListResponse.of(universityNameList);
+	}
+
+	public University getUniversityByName(String name){
+		University university = universityRepository.findByName(name)
+			.orElseThrow(()->new NotFoundException(ErrorCode.UNIVERSITY_NOT_FOUND));
+		return university;
+	}
+}

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/controller/UserPreCertificationController.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/controller/UserPreCertificationController.java
@@ -1,5 +1,6 @@
 package org.sopt.certi_server.domain.userprecertification.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping(value = "/api/v1/home/pre-certification")
 @RequiredArgsConstructor
+@Tag(name = "UserPreCertificationController 컨트롤러", description = "취득예젇과 관련된 API를 처리합니다.")
 public class UserPreCertificationController {
 
      private final UserPreCertificationService userPreCertificationService;

--- a/src/main/java/org/sopt/certi_server/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/certi_server/global/config/SecurityConfig.java
@@ -29,7 +29,8 @@ public class SecurityConfig {
         "/api/v1/auth/sign-up",
         "/api/v1/auth/sign-in",
         "/api/v1/auth/reissue",
-        "/api/v1/admin/**"
+        "/api/v1/admin/**",
+        "/api/v1/university/**"
     };
 
 

--- a/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
+++ b/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
 	CERTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, " E404009", "자격증이 존재하지 않습니다"),
 	AGENCY_NOT_FOUND(HttpStatus.NOT_FOUND, "E404010", "존재하지 않는 인증기관입니다."),
 	CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "E404011", "존재하지 않는 카테고리입니다."),
+	UNIVERSITY_NOT_FOUND(HttpStatus.NOT_FOUND, "E404012", "존재하지 않는 대학교입니다"),
 
 
 	/* 409 CONFLICT */

--- a/src/main/java/org/sopt/certi_server/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/certi_server/global/filter/JwtAuthenticationFilter.java
@@ -31,7 +31,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         "/api/v1/auth/sign-up",
         "/api/v1/auth/sign-in",
         "/api/v1/auth/reissue",
-        "/api/v1/admin/**"
+        "/api/v1/admin/**",
+        "/api/v1/university/**"
+
     );
 
     private final JwtExtractor jwtExtractor;


### PR DESCRIPTION
## 📣 Related Issue

- close #100 

## 📝 Summary

- 대학교 검색을 해야해서 대학교 엔티티를 따로 만들어주었습니다
- 그에따라 User와 일대다 관계로 매핑해주고 전반적으로 수정하였습니다
- 대학교 검색 API를 구현하였습니다


## 📬 Postman

<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/09e6cf62-a894-45fe-885e-130b615044ee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 대학 검색을 위한 엔드포인트가 추가되어, 키워드로 대학 목록을 조회할 수 있습니다.

* **버그 수정**
  * 회원 정보 및 회원가입 응답에서 대학명이 올바르게 조회되도록 개선되었습니다.

* **보안**
  * 대학 관련 API(/api/v1/university/**)가 인증 없이 접근 가능하도록 허용되었습니다.

* **기타**
  * 대학 정보를 별도의 엔티티로 관리하도록 구조가 개선되었습니다.  
  * 존재하지 않는 대학 조회 시 새로운 에러 메시지가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->