### PR TITLE
#112 [fix] 자격증 - 직무, 전공 매핑 리스트 조회 jpql 쿼리 수정3

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationJobRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationJobRepository.java
@@ -25,8 +25,8 @@ public interface CertificationJobRepository extends JpaRepository<CertificationJ
     @Query("""
         select cj
         from CertificationJob cj
-        left join fetch cj.certification c
-        join fetch c.tags
+        join fetch cj.certification c
+        left join fetch c.tags
         where cj.job.name in :jobNames
 """)
     List<CertificationJob> findByJobNames(List<String> jobNames);
@@ -34,8 +34,8 @@ public interface CertificationJobRepository extends JpaRepository<CertificationJ
     @Query("""
         select cj
         from CertificationJob cj
-        left join fetch cj.certification c
-        join fetch c.tags
+        join fetch cj.certification c
+        left join fetch c.tags
         where cj.job.id in :jobIds
 """)
     List<CertificationJob> findByJobIds(List<Long> jobIds);

--- a/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationMajorRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationMajorRepository.java
@@ -24,8 +24,8 @@ public interface CertificationMajorRepository extends JpaRepository<Certificatio
     @Query("""
         select cm
         from CertificationMajor cm
-        left join fetch cm.certification c
-        join fetch c.tags
+        join fetch cm.certification c
+        left join fetch c.tags
         where cm.major.name in :majorNames
 """)
     List<CertificationMajor> findByMajorNames(List<String> majorNames);
@@ -34,8 +34,8 @@ public interface CertificationMajorRepository extends JpaRepository<Certificatio
     @Query("""
         select cm
         from CertificationMajor cm
-        left join fetch cm.certification c
-        join fetch c.tags
+        join fetch cm.certification c
+        left join fetch c.tags
         where cm.major.id in :majorIds
 """)
     List<CertificationMajor> findByMajorIds(List<Long> majorIds);


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 인증 직업 및 전공 관련 데이터 조회 시 일부 조건에서 결과가 누락되던 문제를 수정하여, 인증 정보가 반드시 존재할 때만 결과가 반환되도록 개선되었습니다. 태그 정보는 선택적으로 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->