### PR TITLE
Feat/#120 Refresh Token 저장 로직 구현 및 회원탈퇴 API 구현

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/acquisition/repository/AcquisitionRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/acquisition/repository/AcquisitionRepository.java
@@ -26,4 +26,6 @@ public interface AcquisitionRepository extends JpaRepository<Acquisition, Long> 
     boolean existsByUserAndCertification(User user, Certification certification);
 
     int countByUser(User user);
+
+	void deleteAllByUser(User user);
 }

--- a/src/main/java/org/sopt/certi_server/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/favorite/repository/FavoriteRepository.java
@@ -27,4 +27,6 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     void deleteAllByCertification(Certification certification);
 
     boolean existsByUserAndCertification(User user, Certification certification);
+
+	void deleteAllByUser(User user);
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/controller/AuthController.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/controller/AuthController.java
@@ -17,6 +17,7 @@ import org.sopt.certi_server.global.annotation.DisableSwaggerSecurity;
 import org.sopt.certi_server.global.error.code.SuccessCode;
 import org.sopt.certi_server.global.error.dto.SuccessResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -80,6 +81,15 @@ public class AuthController {
             @RequestHeader("Authorization") @NotEmpty(message = "해당 api에는 authorization 헤더가 필수입니다.") String authorization
     ) {
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, authService.reIssueToken(authorization)));
+    }
+
+    @DeleteMapping("/withdraw")
+    @Operation(summary = "회원탈퇴 API", description = "회원 탈퇴를 진행합니다")
+    public ResponseEntity<SuccessResponse> withdraw(
+        @AuthenticationPrincipal Long userId
+    ){
+        authService.withdraw(userId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_DELETE));
     }
 
 

--- a/src/main/java/org/sopt/certi_server/domain/user/repository/CareerRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/repository/CareerRepository.java
@@ -19,4 +19,6 @@ public interface CareerRepository extends JpaRepository<Career, Long> {
     Optional<Career> findByUserIdAndId(Long userId, Long id);
 
     int countByUser(User user);
+
+	void deleteAllByUser(User user);
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/repository/UserMajorImplRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/repository/UserMajorImplRepository.java
@@ -1,8 +1,11 @@
 package org.sopt.certi_server.domain.user.repository;
 
+import org.sopt.certi_server.domain.user.entity.User;
 import org.sopt.certi_server.domain.user.entity.UserMajorImpl;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserMajorImplRepository extends JpaRepository<UserMajorImpl, Long> {
     UserMajorImpl findByUserId(Long userId);
+
+	void deleteAllByUser(User user);
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/service/AuthService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/AuthService.java
@@ -2,6 +2,9 @@ package org.sopt.certi_server.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.sopt.certi_server.domain.acquisition.repository.AcquisitionRepository;
+import org.sopt.certi_server.domain.favorite.repository.FavoriteRepository;
 import org.sopt.certi_server.domain.job.entity.Job;
 import org.sopt.certi_server.domain.job.repository.JobRepository;
 import org.sopt.certi_server.domain.major.entity.MajorImpl;
@@ -15,12 +18,15 @@ import org.sopt.certi_server.domain.user.entity.User;
 import org.sopt.certi_server.domain.user.entity.UserJob;
 import org.sopt.certi_server.domain.user.entity.UserMajorImpl;
 import org.sopt.certi_server.domain.user.entity.enums.SocialType;
+import org.sopt.certi_server.domain.user.repository.CareerRepository;
 import org.sopt.certi_server.domain.user.repository.UserJobRepository;
 import org.sopt.certi_server.domain.user.repository.UserMajorImplRepository;
 import org.sopt.certi_server.domain.user.repository.UserRepository;
+import org.sopt.certi_server.domain.userprecertification.repository.UserPreCertificationRepository;
 import org.sopt.certi_server.global.error.code.ErrorCode;
 import org.sopt.certi_server.global.error.exception.NotFoundException;
 import org.sopt.certi_server.global.jwt.domain.service.JwtService;
+import org.sopt.certi_server.global.jwt.domain.service.TokenService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +47,12 @@ public class AuthService {
     private final JwtService jwtService;
     private final KakaoService kakaoService;
     private final UniversityService universityService;
+    private final TokenService tokenService;
+    private final UserService userService;
+    private final UserPreCertificationRepository userPreCertificationRepository;
+    private final AcquisitionRepository acquisitionRepository;
+    private final FavoriteRepository favoriteRepository;
+    private final CareerRepository careerRepository;
 
     public AuthResponse login(OAuthUserInformation userInfo) {
         return userRepository.findByEmail(userInfo.email())
@@ -84,6 +96,8 @@ public class AuthService {
         userMajorImplRepository.save(UserMajorImpl.createUserMajorImpl(newUser, major));
 
         JwtResponse token = jwtService.issueToken(newUser.getId());
+        tokenService.saveRefreshToken(newUser.getId(), token.refreshToken());
+
         return SignUpResponse.of(
                 newUser,
                 major,
@@ -117,6 +131,37 @@ public class AuthService {
                 .major(majorImpl)
                 .university(universityService.getUniversityByName(request.university()))
                 .build();
+    }
+
+    @Transactional
+    public void withdraw(final Long userId){
+        User user = userService.getUser(userId);
+
+        //희망 직무 삭제
+        userJobRepository.deleteAllByUser(user);
+
+        //사용자 전공 삭제
+        userMajorImplRepository.deleteAllByUser(user);
+
+        //사용자 취득 자격증 삭제
+        userPreCertificationRepository.deleteAllByUser(user);
+
+        //사용자 취득 예정 자격증 삭제
+        acquisitionRepository.deleteAllByUser(user);
+
+        //즐겨찾기 항목 삭제
+        favoriteRepository.deleteAllByUser(user);
+
+        //경력 사항 삭제
+        careerRepository.deleteAllByUser(user);
+
+        //토큰 삭제
+        tokenService.deleteRefreshToken(userId);
+
+        //사용자 탈퇴
+        userRepository.delete(user);
+
+        log.info("정상적으로 탈퇴되었습니다");
     }
 
 }

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/repository/UserPreCertificationRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/repository/UserPreCertificationRepository.java
@@ -29,4 +29,6 @@ public interface UserPreCertificationRepository extends JpaRepository<UserPreCer
     boolean existsByUserAndCertification(User user, Certification certification);
 
     Optional<UserPreCertification> findByUserAndCertification(User user, Certification certification);
+
+	void deleteAllByUser(User user);
 }

--- a/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
+++ b/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
@@ -14,9 +14,9 @@ public enum ErrorCode {
     MISSING_HEADER(HttpStatus.BAD_REQUEST, "E400004", "필수 요청 헤더가 누락되었습니다."),
     TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "E400005", "요청 값 타입이 올바르지 않습니다"),
     DATA_INTEGRITY_VIOLATION(HttpStatus.BAD_REQUEST, "E400006", "데이터 무결성 제약 조건을 위반했습니다"),
-    TEST_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "E400006", "요청 테스트 타입이 올바르지 않습니다"),
-    JOB_SIZE_ERROR(HttpStatus.BAD_REQUEST, "E400007", "희망 분야는 1~3개까지 선택가능합니다"),
-    MISSMATCH_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "E400008", "리프레시 토큰이 일치하지 않습니다"),
+    TEST_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "E400007", "요청 테스트 타입이 올바르지 않습니다"),
+    JOB_SIZE_ERROR(HttpStatus.BAD_REQUEST, "E400008", "희망 분야는 1~3개까지 선택가능합니다"),
+    MISMATCH_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "E400009", "리프레시 토큰이 일치하지 않습니다"),
 
     /* 401 */
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E401001", "리소스 접근 권한이 없습니다."),
@@ -41,8 +41,8 @@ public enum ErrorCode {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "E404011", "존재하지 않는 카테고리입니다."),
     UNIVERSITY_NOT_FOUND(HttpStatus.NOT_FOUND, "E404012", "존재하지 않는 대학교입니다"),
     ACQUISITION_NOT_FOUND(HttpStatus.NOT_FOUND, "E404013", "존재하지 않는 취득 정보입니다."),
-    PRECERTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "E404013", "존재하지 않는 취득예정 정보입니다."),
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "E404014", "존재하지 않는 리프레시 토큰입니다"),
+    PRECERTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "E404014", "존재하지 않는 취득예정 정보입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "E404015", "존재하지 않는 리프레시 토큰입니다"),
 
 
     /* 409 CONFLICT */

--- a/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
+++ b/src/main/java/org/sopt/certi_server/global/error/code/ErrorCode.java
@@ -16,9 +16,11 @@ public enum ErrorCode {
     DATA_INTEGRITY_VIOLATION(HttpStatus.BAD_REQUEST, "E400006", "데이터 무결성 제약 조건을 위반했습니다"),
     TEST_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "E400006", "요청 테스트 타입이 올바르지 않습니다"),
     JOB_SIZE_ERROR(HttpStatus.BAD_REQUEST, "E400007", "희망 분야는 1~3개까지 선택가능합니다"),
+    MISSMATCH_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "E400008", "리프레시 토큰이 일치하지 않습니다"),
 
     /* 401 */
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E401001", "리소스 접근 권한이 없습니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "E401002", "리프레시 토큰이 만료되었습니다"),
 
     /* 403  FORBIDDEN */
 
@@ -40,6 +42,7 @@ public enum ErrorCode {
     UNIVERSITY_NOT_FOUND(HttpStatus.NOT_FOUND, "E404012", "존재하지 않는 대학교입니다"),
     ACQUISITION_NOT_FOUND(HttpStatus.NOT_FOUND, "E404013", "존재하지 않는 취득 정보입니다."),
     PRECERTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "E404013", "존재하지 않는 취득예정 정보입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "E404014", "존재하지 않는 리프레시 토큰입니다"),
 
 
     /* 409 CONFLICT */

--- a/src/main/java/org/sopt/certi_server/global/jwt/core/JwtValidator.java
+++ b/src/main/java/org/sopt/certi_server/global/jwt/core/JwtValidator.java
@@ -3,6 +3,8 @@ package org.sopt.certi_server.global.jwt.core;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.sopt.certi_server.global.error.code.ErrorCode;
 import org.sopt.certi_server.global.error.exception.UnauthorizedException;
 import org.springframework.stereotype.Component;
 
@@ -43,6 +45,12 @@ public class JwtValidator {
     public void validatePreSignupToken(String token) {
         if (isExpired(token) || !hasEmail(token)) {
             throw new UnauthorizedException();
+        }
+    }
+
+    public void validateRefreshToken(String token) {
+        if (isExpired(token) || !hasUserId(token)) {
+            throw new UnauthorizedException(ErrorCode.REFRESH_TOKEN_EXPIRED);
         }
     }
 }

--- a/src/main/java/org/sopt/certi_server/global/jwt/domain/entity/Token.java
+++ b/src/main/java/org/sopt/certi_server/global/jwt/domain/entity/Token.java
@@ -10,7 +10,7 @@ import org.springframework.data.redis.core.index.Indexed;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @RedisHash(value = "refresh_token")
-public class Token {
+public class  Token {
 
     //userId
     @Id

--- a/src/main/java/org/sopt/certi_server/global/jwt/domain/entity/Token.java
+++ b/src/main/java/org/sopt/certi_server/global/jwt/domain/entity/Token.java
@@ -10,7 +10,7 @@ import org.springframework.data.redis.core.index.Indexed;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @RedisHash(value = "refresh_token")
-public class  Token {
+public class Token {
 
     //userId
     @Id

--- a/src/main/java/org/sopt/certi_server/global/jwt/domain/service/JwtService.java
+++ b/src/main/java/org/sopt/certi_server/global/jwt/domain/service/JwtService.java
@@ -6,12 +6,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.sopt.certi_server.domain.user.dto.response.JwtResponse;
 import org.sopt.certi_server.global.error.code.ErrorCode;
 import org.sopt.certi_server.global.error.exception.BadRequestException;
-import org.sopt.certi_server.global.error.exception.NotFoundException;
 import org.sopt.certi_server.global.jwt.core.JwtExtractor;
 import org.sopt.certi_server.global.jwt.core.JwtProvider;
 import org.sopt.certi_server.global.jwt.core.JwtValidator;
 import org.sopt.certi_server.global.jwt.domain.entity.Token;
-import org.sopt.certi_server.global.jwt.domain.repository.TokenRepository;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -53,7 +51,7 @@ public class JwtService {
         Token findRefreshToken = tokenService.getTokenByUserId(userId);
 
         if(!findRefreshToken.getRefreshToken().equals(refreshToken)) {
-            throw new BadRequestException(ErrorCode.MISSMATCH_REFRESH_TOKEN);
+            throw new BadRequestException(ErrorCode.MISMATCH_REFRESH_TOKEN);
         }
         log.info("Refresh 토큰 검증 성공");
 

--- a/src/main/java/org/sopt/certi_server/global/jwt/domain/service/JwtService.java
+++ b/src/main/java/org/sopt/certi_server/global/jwt/domain/service/JwtService.java
@@ -1,19 +1,28 @@
 package org.sopt.certi_server.global.jwt.domain.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.sopt.certi_server.domain.user.dto.response.JwtResponse;
+import org.sopt.certi_server.global.error.code.ErrorCode;
+import org.sopt.certi_server.global.error.exception.BadRequestException;
+import org.sopt.certi_server.global.error.exception.NotFoundException;
 import org.sopt.certi_server.global.jwt.core.JwtExtractor;
 import org.sopt.certi_server.global.jwt.core.JwtProvider;
 import org.sopt.certi_server.global.jwt.core.JwtValidator;
+import org.sopt.certi_server.global.jwt.domain.entity.Token;
+import org.sopt.certi_server.global.jwt.domain.repository.TokenRepository;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class JwtService {
 
     private final JwtProvider jwtProvider;
     private final JwtExtractor jwtExtractor;
     private final JwtValidator jwtValidator;
+    private final TokenService tokenService;
 
     public JwtResponse issueToken(Long userId) {
         String accessToken = jwtProvider.generateAccessToken(userId);
@@ -38,9 +47,25 @@ public class JwtService {
      */
     public JwtResponse reissueToken(String authorizationHeader) {
         String refreshToken = jwtExtractor.extractToken(authorizationHeader);
-        jwtValidator.validateAccessToken(refreshToken); // 또는 refresh 전용 validator 추가 가능
+        jwtValidator.validateRefreshToken(refreshToken); // 또는 refresh 전용 validator 추가 가능
         Long userId = jwtExtractor.extractUserId(refreshToken);
-        return issueToken(userId);
+
+        Token findRefreshToken = tokenService.getTokenByUserId(userId);
+
+        if(!findRefreshToken.getRefreshToken().equals(refreshToken)) {
+            throw new BadRequestException(ErrorCode.MISSMATCH_REFRESH_TOKEN);
+        }
+        log.info("Refresh 토큰 검증 성공");
+
+        tokenService.deleteRefreshToken(userId);
+
+        String newAccessToken = jwtProvider.generateAccessToken(userId);
+        String newRefreshToken = jwtProvider.generateRefreshToken(userId);
+
+        tokenService.saveRefreshToken(userId, newRefreshToken);
+
+        return JwtResponse.of(newAccessToken, newRefreshToken);
+
     }
 
 

--- a/src/main/java/org/sopt/certi_server/global/jwt/domain/service/TokenService.java
+++ b/src/main/java/org/sopt/certi_server/global/jwt/domain/service/TokenService.java
@@ -1,0 +1,47 @@
+package org.sopt.certi_server.global.jwt.domain.service;
+
+import org.sopt.certi_server.global.error.code.ErrorCode;
+import org.sopt.certi_server.global.error.exception.NotFoundException;
+import org.sopt.certi_server.global.jwt.domain.entity.Token;
+import org.sopt.certi_server.global.jwt.domain.repository.TokenRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TokenService {
+
+	private final TokenRepository tokenRepository;
+
+	@Transactional
+	public void saveRefreshToken(final Long userId, final String refreshToken) {
+		log.info("Saving refresh token for userId : {}", userId);
+		tokenRepository.save(Token.of(userId, refreshToken));
+		log.info("Successfully Refresh token for userId : {}", userId);
+	}
+
+	public Long findIdByRefreshToken(final String refreshToken) {
+		log.info("findIdByRefreshToken : {}", refreshToken);
+		Token token = tokenRepository.findByRefreshToken(refreshToken)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+		return token.getId();
+	}
+
+	@Transactional
+	public void deleteRefreshToken(final Long userId) {
+		log.info("Deleting refresh token for userId : {}", userId);
+		Token token = tokenRepository.findById(userId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+		tokenRepository.delete(token);
+		log.info("Successfully deleted refresh token for userId : {}", userId);
+	}
+
+	public Token getTokenByUserId(final Long userId) {
+		return tokenRepository.findById(userId)
+			.orElseThrow(()-> new NotFoundException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+	}
+}


### PR DESCRIPTION
## 📣 Related Issue

- close #120 

## 📝 Summary

- Redis를 활용한 Refresh Token 저장/삭제 로직 구현
- Refresh Token 검증 로직 추가
- 회원탈퇴 API 구현

## 📬 Postman

<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/77cdfd6e-2173-4ef5-8a84-6484b4046849" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자 탈퇴(계정 삭제) 엔드포인트가 추가되어, 회원이 자신의 계정을 직접 삭제할 수 있습니다.
  * 사용자 탈퇴 시 관련된 인증, 취득, 즐겨찾기, 경력 등 모든 데이터가 함께 삭제됩니다.
  * 리프레시 토큰 관리 기능이 추가되어, 토큰 저장 및 삭제가 안전하게 처리됩니다.

* **버그 수정**
  * 일부 오류 코드가 중복되거나 잘못 지정된 부분이 수정되었습니다.

* **개선 사항**
  * 리프레시 토큰 재발급 시 유효성 검증 및 일치 여부 확인이 강화되었습니다.
  * 리프레시 토큰 관련 오류 메시지가 추가되어, 만료 및 불일치 상황에서 더 명확한 안내가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->