### PR TITLE
#130 [HOTFIX] 경력사항, 대외활동 추가 요청 API LocalDateTime Json 포맷 변경

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/activity/dto/request/CreateActivityRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/activity/dto/request/CreateActivityRequest.java
@@ -1,5 +1,7 @@
 package org.sopt.certi_server.domain.activity.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -7,8 +9,10 @@ import java.time.LocalDate;
 
 public record CreateActivityRequest(
         @NotNull(message = "활동 시작일은 필수 입력값입니다.")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
         LocalDate startAt,
         @NotNull(message = "활동 종료일은 필수 입력값입니다")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
         LocalDate endAt,
         @NotNull(message = "소속은 필수 입력값입니다")
         @Size(max = 10, message = "최대 10자까지 입력가능합니다.")

--- a/src/main/java/org/sopt/certi_server/domain/certification/entity/Certification.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/entity/Certification.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.sopt.certi_server.domain.certification.entity.enums.CertificationType;
 import org.sopt.certi_server.domain.certification.entity.enums.TestType;
 import org.sopt.certi_server.global.entity.BaseTimeEntity;
@@ -48,6 +49,7 @@ public class Certification extends BaseTimeEntity {
 
     @ElementCollection
     @CollectionTable(name = "tags")
+    @BatchSize(size = 50)
     private List<String> tags = new ArrayList<>();
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationJobRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationJobRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface CertificationJobRepository extends JpaRepository<CertificationJob, Long> {
+public interface CertificationJobRepository extends JpaRepository<CertificationJob, Long>, CertificationJobRepositoryCustom {
 
     @Query("select cj from CertificationJob cj join fetch cj.certification where cj.certification = :certification")
     List<CertificationJob> findAllByCertification(Certification certification);

--- a/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationJobRepositoryCustom.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationJobRepositoryCustom.java
@@ -1,0 +1,10 @@
+package org.sopt.certi_server.domain.certification.repository;
+
+import com.querydsl.core.Tuple;
+
+import java.util.List;
+
+public interface CertificationJobRepositoryCustom {
+
+    List<Tuple> findByJobIds(List<Long> jobIds, Long userId);
+}

--- a/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationJobRepositoryImpl.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationJobRepositoryImpl.java
@@ -1,0 +1,36 @@
+package org.sopt.certi_server.domain.certification.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.sopt.certi_server.domain.certification.dto.response.CertificationSimple;
+import org.sopt.certi_server.domain.certification.entity.QCertification;
+import org.sopt.certi_server.domain.certification.entity.QCertificationJob;
+import org.sopt.certi_server.domain.favorite.entity.QFavorite;
+import org.sopt.certi_server.domain.user.entity.User;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CertificationJobRepositoryImpl implements CertificationJobRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+
+    @Override
+    public List<Tuple> findByJobIds(List<Long> jobIds, Long userId) {
+        QCertification certification = QCertification.certification;
+        QCertificationJob certificationJob = QCertificationJob.certificationJob;
+        QFavorite favorite = QFavorite.favorite;
+
+        return jpaQueryFactory.select(certificationJob, favorite)
+                .from(certificationJob)
+                .join(certificationJob.certification, certification).fetchJoin()
+                .leftJoin(favorite).on(certification.id.eq(favorite.certification.id)
+                        .and(favorite.user.id.eq(userId)))
+                .where(certificationJob.job.id.in(jobIds))
+                .distinct()
+                .fetch();
+
+    }
+}

--- a/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationMajorRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationMajorRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface CertificationMajorRepository extends JpaRepository<CertificationMajor, Long> {
+public interface CertificationMajorRepository extends JpaRepository<CertificationMajor, Long>, CertificationMajorRepositoryCustom {
     Optional<CertificationMajor> findByCertificationAndMajor(Certification certification, Major major);
 
     @Query("select cm from CertificationMajor cm join fetch cm.major where cm.certification = :certification")

--- a/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationMajorRepositoryCustom.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationMajorRepositoryCustom.java
@@ -1,0 +1,11 @@
+package org.sopt.certi_server.domain.certification.repository;
+
+
+import com.querydsl.core.Tuple;
+
+import java.util.List;
+
+public interface CertificationMajorRepositoryCustom {
+
+    List<Tuple> findByMajorIds(List<Long> majorIds, Long userId);
+}

--- a/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationMajorRepositoryImpl.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationMajorRepositoryImpl.java
@@ -1,0 +1,34 @@
+package org.sopt.certi_server.domain.certification.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.sopt.certi_server.domain.certification.entity.QCertification;
+import org.sopt.certi_server.domain.certification.entity.QCertificationMajor;
+import org.sopt.certi_server.domain.favorite.entity.QFavorite;
+import org.sopt.certi_server.domain.major.entity.QMajor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CertificationMajorRepositoryImpl implements CertificationMajorRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Tuple> findByMajorIds(List<Long> majorIds, Long userId) {
+        QCertification certification = QCertification.certification;
+        QCertificationMajor certificationMajor = QCertificationMajor.certificationMajor;
+        QFavorite favorite = QFavorite.favorite;
+
+        return jpaQueryFactory.select(certificationMajor, favorite)
+                .from(certificationMajor)
+                .join(certificationMajor.certification, certification).fetchJoin()
+                .leftJoin(favorite)
+                    .on(favorite.certification.eq(certification)
+                            .and(favorite.user.id.eq(userId)))
+                .where(certificationMajor.major.id.in(majorIds))
+                .distinct()
+                .fetch();
+    }
+}

--- a/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
@@ -1,16 +1,16 @@
 package org.sopt.certi_server.domain.certification.service;
 
+import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.certi_server.domain.certification.dto.request.CertificationCreateRequest;
 import org.sopt.certi_server.domain.certification.dto.response.*;
-import org.sopt.certi_server.domain.certification.entity.Agency;
-import org.sopt.certi_server.domain.certification.entity.Certification;
-import org.sopt.certi_server.domain.certification.entity.CertificationJob;
-import org.sopt.certi_server.domain.certification.entity.CertificationMajor;
+import org.sopt.certi_server.domain.certification.entity.*;
 import org.sopt.certi_server.domain.certification.entity.enums.CertificationType;
 import org.sopt.certi_server.domain.certification.entity.enums.TestType;
 import org.sopt.certi_server.domain.certification.repository.*;
+import org.sopt.certi_server.domain.favorite.entity.Favorite;
+import org.sopt.certi_server.domain.favorite.entity.QFavorite;
 import org.sopt.certi_server.domain.favorite.repository.FavoriteRepository;
 import org.sopt.certi_server.domain.job.entity.Job;
 import org.sopt.certi_server.domain.job.repository.JobRepository;
@@ -60,16 +60,13 @@ public class CertificationService {
 
     @Transactional
     public void createCertification(CertificationCreateRequest request) {
-        Agency findAgency = agencyRepository.findByName(request.agencyName())
-                .orElseThrow(() -> new NotFoundException(ErrorCode.AGENCY_NOT_FOUND));
-
         Certification newCertification = convertDtoToEntity(request);
 
         certificationRepository.save(newCertification);
     }
 
 
-    public CertificationRecommendationListResponse recommendCertifications(final Long userId) {
+    public CertificationRecommendationListResponse recommendCertifications(Long userId){
         User user = userService.getUser(userId);
         List<Major> userMajors = majorRepository.findAllByUser(user);
         log.info("=============사용자 전공================");
@@ -84,71 +81,57 @@ public class CertificationService {
             log.info("job name = {}", userJob.getName());
         }
 
-        List<CertificationMajor> certificationMajors = certificationMajorRepository.findByMajorIds(
+        List<Tuple> certificationMajorAndFavoriteTupleList = certificationMajorRepository.findByMajorIds(
                 userMajors.stream()
                         .map(Major::getId)
-                        .toList()
+                        .toList(),
+                userId
         );
-        log.info("=============전공 - 자격증 매핑================");
-        for (CertificationMajor certificationMajor : certificationMajors) {
-            log.info("major = {}", certificationMajor.getMajor().getName());
-            log.info("certification = {}", certificationMajor.getCertification().getName());
-        }
 
-        List<CertificationJob> certificationJobs = certificationJobRepository.findByJobIds(
+        List<Tuple> certificationJobAndFavoriteTupleList = certificationJobRepository.findByJobIds(
                 userJobs.stream()
                         .map(Job::getId)
-                        .toList()
+                        .toList(),
+                userId
         );
-        log.info("=============직무 - 자격증 매핑================");
-        for (CertificationJob certificationJob : certificationJobs) {
-            log.info("major = {}", certificationJob.getJob().getName());
-            log.info("certification = {}", certificationJob.getCertification().getName());
-        }
 
-
-        return getCertificationRecommendationListResponse(certificationMajors, certificationJobs, user);
-    }
-
-    private CertificationRecommendationListResponse getCertificationRecommendationListResponse(final List<CertificationMajor> certificationMajors, final List<CertificationJob> certificationJobs, final User user) {
-        Map<Long, List<CertificationMajor>> certificationMajorMapGroupingByCertification = certificationMajors.stream()
+        Map<Long, List<Tuple>> certificationMajorMap = certificationMajorAndFavoriteTupleList.stream()
                 .collect(Collectors.groupingBy(
-                        cm -> cm.getCertification().getId()
+                        tuple -> Objects.requireNonNull(tuple.get(QCertificationMajor.certificationMajor)).getCertification().getId()
                 ));
 
-
-        Map<Long, List<CertificationJob>> certificationJobMapGroupingByCertification = certificationJobs.stream()
+        Map<Long, List<Tuple>> certificationJobMap = certificationJobAndFavoriteTupleList.stream()
                 .collect(Collectors.groupingBy(
-                        cj -> cj.getCertification().getId()
+                        tuple -> Objects.requireNonNull(tuple.get(QCertificationJob.certificationJob)).getCertification().getId()
                 ));
 
-        Set<Long> allCertificationIds = new HashSet<>();
-        allCertificationIds.addAll(certificationMajorMapGroupingByCertification.keySet());
-        allCertificationIds.addAll(certificationJobMapGroupingByCertification.keySet());
+        Set<Long> allCertIds = new HashSet<>();
+        allCertIds.addAll(certificationMajorMap.keySet());
+        allCertIds.addAll(certificationJobMap.keySet());
 
-        List<CertificationScoreDto> recommendationList = allCertificationIds.stream()
-                .map(certificationId -> {
-                    List<CertificationMajor> certificationMajorListByCertId = certificationMajorMapGroupingByCertification.getOrDefault(certificationId, List.of());
-                    List<CertificationJob> certificationJobListByCertId = certificationJobMapGroupingByCertification.getOrDefault(certificationId, List.of());
-                    Certification certification = certificationMajorListByCertId.isEmpty() ? certificationJobListByCertId.get(0).getCertification() : certificationMajorListByCertId.get(0).getCertification();
+        List<CertificationScoreDto> recommendationList = allCertIds.stream()
+                .map(certId -> {
+                    List<Tuple> certificationMajors = certificationMajorMap.get(certId);
+                    List<Tuple> certificationJobs = certificationJobMap.get(certId);
 
+                    Certification certification = certificationMajors.isEmpty() ? certificationJobs.get(0).get(QCertificationJob.certificationJob).getCertification() : certificationMajors.get(0).get(QCertificationMajor.certificationMajor).getCertification();
+                    Favorite favorite = certificationMajors.isEmpty() ? certificationJobs.get(0).get(QFavorite.favorite) : certificationMajors.get(0).get(QFavorite.favorite);
 
-                    double majorScore = reverseProductScore(certificationMajorListByCertId.stream()
-                            .map(CertificationMajor::getWeight));
-
-                    double jobScore = reverseProductScore(certificationJobListByCertId.stream()
-                            .map(CertificationJob::getWeight));
+                    double majorScore = certificationMajors != null ? reverseProductScore(certificationMajors.stream()
+                            .map(tuple -> tuple.get(QCertificationMajor.certificationMajor).getWeight())) : 0;
+                    double jobScore = certificationJobs != null ? reverseProductScore(certificationJobs.stream()
+                            .map(tuple -> tuple.get(QCertificationJob.certificationJob).getWeight())) : 0;
 
                     int finalScore = (int) ((majorScore * 0.4 + jobScore * 0.6) * 100);
 
-                    return CertificationScoreDto.from(certification, finalScore, favoriteRepository.existsByUserAndCertification(user, certification));
-
+                    return CertificationScoreDto.from(certification, finalScore, favorite != null);
                 })
                 .sorted(Comparator.comparing(CertificationScoreDto::recommendationScore).reversed())
                 .limit(6)
                 .toList();
 
         return CertificationRecommendationListResponse.of(recommendationList);
+
     }
 
     private double reverseProductScore(Stream<Double> weightStream) {

--- a/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
@@ -114,13 +114,18 @@ public class CertificationService {
                     List<Tuple> certificationMajors = certificationMajorMap.get(certId);
                     List<Tuple> certificationJobs = certificationJobMap.get(certId);
 
-                    Certification certification = certificationMajors.isEmpty() ? certificationJobs.get(0).get(QCertificationJob.certificationJob).getCertification() : certificationMajors.get(0).get(QCertificationMajor.certificationMajor).getCertification();
-                    Favorite favorite = certificationMajors.isEmpty() ? certificationJobs.get(0).get(QFavorite.favorite) : certificationMajors.get(0).get(QFavorite.favorite);
+                    Certification certification = certificationMajors == null ?
+                            Objects.requireNonNull(certificationJobs.get(0).get(QCertificationJob.certificationJob)).getCertification() :
+                            Objects.requireNonNull(certificationMajors.get(0).get(QCertificationMajor.certificationMajor)).getCertification();
+
+                    Favorite favorite = certificationMajors == null ?
+                            certificationJobs.get(0).get(QFavorite.favorite) :
+                            certificationMajors.get(0).get(QFavorite.favorite);
 
                     double majorScore = certificationMajors != null ? reverseProductScore(certificationMajors.stream()
-                            .map(tuple -> tuple.get(QCertificationMajor.certificationMajor).getWeight())) : 0;
+                            .map(tuple -> Objects.requireNonNull(tuple.get(QCertificationMajor.certificationMajor)).getWeight())) : 0;
                     double jobScore = certificationJobs != null ? reverseProductScore(certificationJobs.stream()
-                            .map(tuple -> tuple.get(QCertificationJob.certificationJob).getWeight())) : 0;
+                            .map(tuple -> Objects.requireNonNull(tuple.get(QCertificationJob.certificationJob)).getWeight())) : 0;
 
                     int finalScore = (int) ((majorScore * 0.4 + jobScore * 0.6) * 100);
 

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/request/CreateCareerRequest.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/request/CreateCareerRequest.java
@@ -1,5 +1,6 @@
 package org.sopt.certi_server.domain.user.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -7,8 +8,10 @@ import java.time.LocalDate;
 
 public record CreateCareerRequest(
         @NotNull(message = "근무 시작일은 필수 입력값입니다.")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
         LocalDate startAt,
         @NotNull(message = "근무 종료일은 필수 입력값입니다")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
         LocalDate endAt,
         @NotNull(message = "근무 회사는 필수 입력값입니다")
         String place,

--- a/src/test/java/org/sopt/certi_server/domain/certification/repository/CertificationMajorRepositoryImplTest.java
+++ b/src/test/java/org/sopt/certi_server/domain/certification/repository/CertificationMajorRepositoryImplTest.java
@@ -1,0 +1,35 @@
+package org.sopt.certi_server.domain.certification.repository;
+
+import com.querydsl.core.Tuple;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class CertificationMajorRepositoryImplTest {
+
+    @Autowired
+    CertificationMajorRepository certificationMajorRepository;
+
+    @Test
+    void certification_major_find_by_major_id_and_user_id(){
+        // given
+        List<Long> majorIds = new ArrayList<>();
+        majorIds.add(8L);
+
+        Long userId = 1L;
+
+        // when
+        List<Tuple> byMajorIds = certificationMajorRepository.findByMajorIds(majorIds, userId);
+
+        // then
+        Assertions.assertThat(byMajorIds.size()).isEqualTo(54);
+
+    }
+}

--- a/src/test/java/org/sopt/certi_server/domain/certification/service/CertificationServiceTest.java
+++ b/src/test/java/org/sopt/certi_server/domain/certification/service/CertificationServiceTest.java
@@ -5,6 +5,7 @@ import org.sopt.certi_server.domain.certification.dto.response.CertificationReco
 import org.sopt.certi_server.domain.certification.dto.response.CertificationScoreDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 class CertificationServiceTest {
@@ -14,7 +15,20 @@ class CertificationServiceTest {
 
     @Test
     void certification_recommandation_test() {
-        CertificationRecommendationListResponse certificationRecommendationListResponse = certificationService.recommendCertifications(3L);
+        CertificationRecommendationListResponse certificationRecommendationListResponse = certificationService.recommendCertifications(1L);
+
+        System.out.println("certificationRecommendationListResponse.recommendationList().size() = " + certificationRecommendationListResponse.recommendationList().size());
+
+        for (CertificationScoreDto certificationScoreDto : certificationRecommendationListResponse.recommendationList()) {
+            System.out.println("certificationScoreDto = " + certificationScoreDto);
+        }
+    }
+
+
+    @Test
+    @Transactional(readOnly = true)
+    void certification_recommandation_testV2() {
+        CertificationRecommendationListResponse certificationRecommendationListResponse = certificationService.recommendCertifications(1L);
 
         System.out.println("certificationRecommendationListResponse.recommendationList().size() = " + certificationRecommendationListResponse.recommendationList().size());
 


### PR DESCRIPTION
## 📣 Related Issue

- close #130 

## 📝 Summary

날짜 형식을 변경하였습니다.

## 🙏 Question & PR point

날짜 형식은 요청, 응답 모두 yy.MM.dd로 통일할 것

## 📬 Postman




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 자격증 추천 기능에서 즐겨찾기 정보를 함께 제공하고, 추천 결과에 즐겨찾기 여부가 반영됩니다.
  * 전공 및 직무 기반 자격증 추천 시, 사용자 ID와 전공/직무 ID로 맞춤 추천이 가능해졌습니다.

* **버그 수정**
  * 활동 및 경력 생성 요청 시 날짜 필드의 JSON 포맷이 "yyyy.MM.dd" 및 "Asia/Seoul" 타임존으로 통일되어 일관성 있는 날짜 처리가 보장됩니다.

* **테스트**
  * 전공 기반 자격증 추천 및 자격증 추천 서비스에 대한 통합 테스트가 추가되어, 추천 결과의 정확성이 검증됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->