### PR TITLE
#134 [fix] 자격증 취득완료 시 취득예정에서 삭제

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/acquisition/service/AcquisitionService.java
+++ b/src/main/java/org/sopt/certi_server/domain/acquisition/service/AcquisitionService.java
@@ -11,6 +11,8 @@ import org.sopt.certi_server.domain.certification.entity.Certification;
 import org.sopt.certi_server.domain.certification.service.CertificationService;
 import org.sopt.certi_server.domain.user.entity.User;
 import org.sopt.certi_server.domain.user.service.UserService;
+import org.sopt.certi_server.domain.userprecertification.entity.UserPreCertification;
+import org.sopt.certi_server.domain.userprecertification.repository.UserPreCertificationRepository;
 import org.sopt.certi_server.global.error.code.ErrorCode;
 import org.sopt.certi_server.global.error.exception.ForbiddenException;
 import org.sopt.certi_server.global.error.exception.NotFoundException;
@@ -28,6 +30,7 @@ import static org.sopt.certi_server.domain.acquisition.entity.enums.CardType.iss
 @Slf4j
 public class AcquisitionService {
     private final AcquisitionRepository acquisitionRepository;
+    private final UserPreCertificationRepository userPreCertificationRepository;
     private final UserService userService;
     private final CertificationService certificationService;
 
@@ -56,6 +59,11 @@ public class AcquisitionService {
                 .build();
 
         acquisitionRepository.save(acquisition);
+
+        //취득 예정 자격증에서 삭제
+        UserPreCertification findUserPreCertification = userPreCertificationRepository.findByUserAndCertification(user, certification)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.PRECERTIFICATION_NOT_FOUND));
+        userPreCertificationRepository.delete(findUserPreCertification);
 
         return true;
     }


### PR DESCRIPTION
## 📣 Related Issue

- close #134 

## 📝 Summary

자격증 취득 완료시 취득 예정 자격증에서 삭제




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 자격증 취득 시, 해당 유저의 사전 인증 기록이 존재하지 않을 경우 오류 메시지가 표시됩니다.
  * 자격증 취득이 완료되면 관련 사전 인증 기록이 자동으로 삭제되어 정보가 동기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->