### PR TITLE
#139 [fix] 취득 자격증에 대해 취득 예정 불가 로직 추가

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/service/UserPreCertificationService.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/service/UserPreCertificationService.java
@@ -1,6 +1,7 @@
 package org.sopt.certi_server.domain.userprecertification.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.certi_server.domain.acquisition.repository.AcquisitionRepository;
 import org.sopt.certi_server.domain.certification.entity.Certification;
 import org.sopt.certi_server.domain.certification.service.CertificationService;
 import org.sopt.certi_server.domain.user.entity.User;
@@ -11,6 +12,8 @@ import org.sopt.certi_server.domain.userprecertification.entity.UserPreCertifica
 import org.sopt.certi_server.domain.userprecertification.entity.enums.IconType;
 import org.sopt.certi_server.domain.userprecertification.repository.UserPreCertificationRepository;
 import org.sopt.certi_server.global.error.code.ErrorCode;
+import org.sopt.certi_server.global.error.exception.BusinessException;
+import org.sopt.certi_server.global.error.exception.ForbiddenException;
 import org.sopt.certi_server.global.error.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +26,7 @@ public class UserPreCertificationService {
     private final UserService userService;
     private final CertificationService certificationService;
     private final UserPreCertificationRepository userPreCertificationRepository;
+    private final AcquisitionRepository acquisitionRepository;
 
     public PreCertificationSimpleListResponse getPreCertificationListDataByUserId(Long userId) {
         return new PreCertificationSimpleListResponse(userPreCertificationRepository.getPreCertificationsByUserId(userId).stream()
@@ -34,6 +38,10 @@ public class UserPreCertificationService {
     public boolean createNewPreCertification(final Long userId, final Long certificationId) {
         User user = userService.getUser(userId);
         Certification certification = certificationService.getCertification(certificationId);
+
+        if(acquisitionRepository.existsByUserAndCertification(user, certification)){
+            throw new BusinessException(ErrorCode.DUPLICATED_ACQUISITION);
+        }
 
         if (userPreCertificationRepository.existsByUserAndCertification(user, certification)) {
             return false;


### PR DESCRIPTION

## 📣 Related Issue

- close #139 

## 📝 Summary

- 이미 취득한 자격증에 대해서 취득 예정 시 충돌로 간주

## 🙏 Question & PR point

Conflict에 대한 BusinessException이 필요할 거 같음

## 📬 Postman
<img width="903" height="951" alt="image" src="https://github.com/user-attachments/assets/8a66c5ad-d2f9-4f97-ae40-ebcf5aa4595b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 사용자가 이미 해당 자격증을 취득한 경우, 사전 인증을 생성할 수 없도록 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->