### PR TITLE
#162 [refactor] 소셜 로그인 시 회원 판별 기준 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # baseimage -> 컨테이너의 내 애플리케이션이 돌아갈 수 있는 환경을 제공해주는 이미지
-FROM openjdk:17-jdk
+FROM eclipse-temurin:17-jdk
 
 RUN ln -snf /usr/share/zoneinfo/Asia/Seoul /etc/localtime
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # baseimage -> 컨테이너의 내 애플리케이션이 돌아갈 수 있는 환경을 제공해주는 이미지
-FROM eclipse-temurin:17-jdk
+FROM amazoncorretto:17
 
 RUN ln -snf /usr/share/zoneinfo/Asia/Seoul /etc/localtime
 

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/response/OAuthUserInformation.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/response/OAuthUserInformation.java
@@ -2,8 +2,11 @@ package org.sopt.certi_server.domain.user.dto.response;
 
 import jakarta.validation.constraints.NotEmpty;
 import org.sopt.certi_server.domain.user.dto.response.kakao.KakaoUserInformationResponse;
+import org.sopt.certi_server.domain.user.entity.enums.SocialType;
 
 public record OAuthUserInformation(
+        Long socialId,
+        SocialType socialType,
         String email,
         @NotEmpty(message = "사용자 닉네임 정보는 필수입니다.") String nickname,
         String profileImageUrl
@@ -12,6 +15,8 @@ public record OAuthUserInformation(
             KakaoUserInformationResponse information
     ) {
         return new OAuthUserInformation(
+                information.id(),
+                SocialType.KAKAO,
                 information.kakaoAccount().email(),
                 information.kakaoAccount().profile().nickname(),
                 information.kakaoAccount().profile().profileImageUrl()

--- a/src/main/java/org/sopt/certi_server/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/entity/User.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.certi_server.domain.major.entity.MajorImpl;
 import org.sopt.certi_server.domain.user.entity.enums.Grade;
+import org.sopt.certi_server.domain.user.entity.enums.SocialType;
 import org.sopt.certi_server.domain.user.entity.enums.TrackType;
 import org.sopt.certi_server.global.entity.BaseTimeEntity;
 
@@ -45,6 +46,13 @@ public class User extends BaseTimeEntity {
     @Column(name = "profile_image_url")
     private String profileImageUrl;
 
+    @Column(name = "social_type")
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType;
+
+    @Column(name = "social_id")
+    private Long socialId;
+
 
     public User(String nickname, String email, String profileImageUrl) {
         this.nickname = nickname;
@@ -54,7 +62,7 @@ public class User extends BaseTimeEntity {
 
     @Builder
     public User(Long id, University university, String track, String grade, MajorImpl major, String nickname, String email,
-                String profileImageUrl) {
+                String profileImageUrl, SocialType socialType, Long socialId) {
         this.id = id;
         this.university = university;
         this.track = TrackType.from(track);
@@ -63,6 +71,8 @@ public class User extends BaseTimeEntity {
         this.nickname = nickname;
         this.email = email;
         this.profileImageUrl = profileImageUrl;
+        this.socialType = socialType;
+        this.socialId = socialId;
     }
 
     public static User createUser(String nickname, String email, String profileImageUrl) {

--- a/src/main/java/org/sopt/certi_server/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package org.sopt.certi_server.domain.user.repository;
 
 import org.sopt.certi_server.domain.user.entity.User;
+import org.sopt.certi_server.domain.user.entity.enums.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,7 +9,7 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    boolean existsByEmail(String email);
+    Optional<User> findBySocialTypeAndSocialId(SocialType socialType, Long socialId);
 
     Optional<User> findByEmail(String email);
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/service/AuthService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/AuthService.java
@@ -57,13 +57,13 @@ public class AuthService {
     private final ActivityRepository activityRepository;
 
     public AuthResponse login(OAuthUserInformation userInfo) {
-        return userRepository.findByEmail(userInfo.email())
+        return userRepository.findBySocialTypeAndSocialId(userInfo.socialType(), userInfo.socialId())
                 .map(this::handleExistingUser)
                 .orElseGet(() -> handleNewUser(userInfo));
     }
 
     private AuthResponse handleNewUser(OAuthUserInformation userInfo) {
-        String preSignupToken = jwtService.generatePreSignupToken(userInfo.email());
+        String preSignupToken = jwtService.generatePreSignupToken(userInfo.socialId());
         return AuthResponse.ofNotRegisteredUser(preSignupToken, userInfo);
     }
 
@@ -132,6 +132,8 @@ public class AuthService {
                 .grade(request.grade())
                 .major(majorImpl)
                 .university(universityService.getUniversityByName(request.university()))
+                .socialType(request.userInformation().socialType())
+                .socialId(request.userInformation().socialId())
                 .build();
     }
 

--- a/src/main/java/org/sopt/certi_server/global/jwt/core/JwtProvider.java
+++ b/src/main/java/org/sopt/certi_server/global/jwt/core/JwtProvider.java
@@ -16,7 +16,7 @@ import java.util.Map;
 public class JwtProvider {
 
     private static final String USER_ID = "userId";
-    private static final String USER_EMAIL = "userEmail";
+    private static final String SOCIAL_ID = "socialId";
 
     private final JwtProperties jwtProperties;
     private final SecretKey secretKey;
@@ -29,8 +29,8 @@ public class JwtProvider {
         return generateToken(Map.of(USER_ID, userId), jwtProperties.getRefreshTokenExpirationTime());
     }
 
-    public String generatePreSignupToken(String email) {
-        return generateToken(Map.of(USER_EMAIL, email), jwtProperties.getPreSignupTokenExpirationTime());
+    public String generatePreSignupToken(Long socialId){
+        return generateToken(Map.of(SOCIAL_ID, socialId), jwtProperties.getPreSignupTokenExpirationTime());
     }
 
     public String generateToken(Map<String, Object> claims, long expirationTime) {

--- a/src/main/java/org/sopt/certi_server/global/jwt/core/JwtValidator.java
+++ b/src/main/java/org/sopt/certi_server/global/jwt/core/JwtValidator.java
@@ -31,19 +31,13 @@ public class JwtValidator {
         return claims.get("userId") != null;
     }
 
-    public boolean hasEmail(String token) {
+    public boolean hasSocialId(String token){
         Claims claims = jwtExtractor.extractClaims(token);
-        return claims.get("userEmail") != null;
-    }
-
-    public void validateAccessToken(String token) {
-        if (isExpired(token) || !hasUserId(token)) {
-            throw new UnauthorizedException();
-        }
+        return claims.get("socialId") != null;
     }
 
     public void validatePreSignupToken(String token) {
-        if (isExpired(token) || !hasEmail(token)) {
+        if (isExpired(token) || !hasSocialId(token)) {
             throw new UnauthorizedException();
         }
     }

--- a/src/main/java/org/sopt/certi_server/global/jwt/domain/service/JwtService.java
+++ b/src/main/java/org/sopt/certi_server/global/jwt/domain/service/JwtService.java
@@ -28,8 +28,8 @@ public class JwtService {
         return JwtResponse.of(accessToken, refreshToken);
     }
 
-    public String generatePreSignupToken(String email) {
-        return jwtProvider.generatePreSignupToken(email);
+    public String generatePreSignupToken(Long socialId){
+        return jwtProvider.generatePreSignupToken(socialId);
     }
 
     /**


### PR DESCRIPTION
## 📣 Related Issue

- close #162 

## 📝 Summary

- 애플 로그인이 추가된다면, 해당 유저가 카카오로 로그인한 유저인지, 애플로 로그인한 유저인지 판단할 수 있어야 힌디거 생각했습니다.
- 따라서 User 정보로 SocialType과 SocialId를 추가적으로 저장하도록 엔티티에 필드값을 추가했고, 이에 따라서 소셜 로그인 플로우에서 사용되던 DTO에도 해당 값들이 저장되도록 변경했습니다.
<img width="277" height="105" alt="image" src="https://github.com/user-attachments/assets/9c414bdc-802d-4db2-a394-536efe238269" />
<img width="697" height="142" alt="image" src="https://github.com/user-attachments/assets/c2406707-1b13-4a37-b519-7b9e017fe962" />

- 또한 기존에 사용자의 유무를 판단하고, preSignupToken 발급 및 검증 시 사용되던 값을 email -> socialId로 변경했습니다.

## 🙏 Question & PR point

- N/A

## 📬 Postman



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 소셜 로그인 사용자를 소셜 ID와 소셜 타입으로 식별하도록 확장했습니다.
  - 신규 사용자 사전가입 토큰 생성이 소셜 ID 기반으로 동작합니다.
- Refactor
  - 로그인 및 사용자 조회 흐름을 이메일 기반에서 소셜 식별 정보 기반으로 전환했습니다.
  - JWT 생성·검증 로직을 사전가입 토큰의 클레임으로 소셜 ID를 사용하도록 개편했습니다.
- Chores
  - 컨테이너 베이스 이미지를 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->