### PR TITLE
Fix/#171 카테고리 API 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: woals2840/certi-server
+          tags: seongmin0229/certi-server
 
   deploy-cd:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,5 @@ jobs:
         context: .
         file: ./Dockerfile
         push: true
-        tags: woals2840/certi-server
+        tags: seongmin0229/certi-server
     

--- a/src/main/java/org/sopt/certi_server/domain/certification/controller/CertificationController.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/controller/CertificationController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.sopt.certi_server.domain.certification.dto.response.CertificationDetailResponse;
 import org.sopt.certi_server.domain.certification.dto.response.CertificationListResponse;
+import org.sopt.certi_server.domain.certification.dto.response.CertificationRankResponse;
 import org.sopt.certi_server.domain.certification.dto.response.CertificationRecommendationListResponse;
 import org.sopt.certi_server.domain.certification.dto.response.CertificationSimple;
 import org.sopt.certi_server.domain.certification.service.CertificationService;
@@ -80,5 +81,25 @@ public class CertificationController {
         CertificationRecommendationListResponse certiRecommendListRes = certificationService.recommendCertifications(userId);
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, certiRecommendListRes));
     }
+
+    @GetMapping("/job")
+    @Operation(summary = "직무별 자격증 조회 API", description = "3순위 직무별 자격증을 조회합니다")
+    public ResponseEntity<SuccessResponse<?>> getTop3ByJob(
+        @AuthenticationPrincipal Long userId
+    ){
+        List<CertificationRankResponse> certificationRankResponseList = certificationService.getCertificationJob(userId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, certificationRankResponseList));
+    }
+
+    @GetMapping("/track")
+    @Operation(summary = "계열별 자격증 조회 API", description = "3순위 계열별 자격증을 조회합니다")
+    public ResponseEntity<SuccessResponse<?>> getTop3ByTrack(
+        @AuthenticationPrincipal Long userId
+    ) {
+        List<CertificationRankResponse> certificationRankResponseList = certificationService.getCertificationTrack(userId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, certificationRankResponseList));
+
+    }
+
 
 }

--- a/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationRankResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationRankResponse.java
@@ -1,0 +1,19 @@
+package org.sopt.certi_server.domain.certification.dto.response;
+
+import org.sopt.certi_server.domain.certification.entity.Certification;
+
+public record CertificationRankResponse(
+	int rank,
+	String certificationName,
+	String certificationType
+) {
+	public CertificationRankResponse(int rank, Certification certification) {
+		this(
+			rank,
+			certification.getName(),
+			certification.getCertificationType() != null
+				? certification.getCertificationType().getKoreanName()
+				: null
+		);
+	}
+}

--- a/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationScoreDto.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationScoreDto.java
@@ -11,7 +11,8 @@ public record CertificationScoreDto(
         String testType,
         List<String> tags,
         int recommendationScore,
-        boolean isFavorite) {
+        boolean isFavorite,
+        String description) {
     public static CertificationScoreDto from(
             Certification certification,
             int recommendationScore,
@@ -24,7 +25,8 @@ public record CertificationScoreDto(
                 certification.getTestType().getType(),
                 certification.getTags(),
                 recommendationScore,
-                isFavorite
+                isFavorite,
+                certification.getDescription()
         );
     }
 

--- a/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationScoreDto.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationScoreDto.java
@@ -11,7 +11,8 @@ public record CertificationScoreDto(
         String testType,
         List<String> tags,
         int recommendationScore,
-        boolean isFavorite) {
+        boolean isFavorite,
+        String description) {
     public static CertificationScoreDto from(
             Certification certification,
             int recommendationScore,
@@ -24,7 +25,8 @@ public record CertificationScoreDto(
                 certification.getTestType().getType(),
                 certification.getTags().stream().toList(),
                 recommendationScore,
-                isFavorite
+                isFavorite,
+                certification.getDescription()
         );
     }
 

--- a/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationSimple.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/dto/response/CertificationSimple.java
@@ -16,6 +16,7 @@ public class CertificationSimple {
     private List<String> tags;
     @JsonProperty(value = "isFavorite")
     private boolean favorite;
+    private String description;
 
     public CertificationSimple(
             Certification certification,
@@ -29,5 +30,6 @@ public class CertificationSimple {
                 certification.getTestType().getType() : null;
         this.tags = certification.getTags();
         this.favorite = favorite;
+        this.description = certification.getDescription();
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
@@ -17,15 +17,19 @@ import org.sopt.certi_server.domain.job.repository.JobRepository;
 import org.sopt.certi_server.domain.major.entity.Major;
 import org.sopt.certi_server.domain.major.repository.MajorRepository;
 import org.sopt.certi_server.domain.user.entity.User;
+import org.sopt.certi_server.domain.user.entity.enums.TrackType;
 import org.sopt.certi_server.domain.user.service.UserService;
 import org.sopt.certi_server.global.error.code.ErrorCode;
 import org.sopt.certi_server.global.error.exception.NotFoundException;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -45,6 +49,7 @@ public class CertificationService {
     private final CertificationJobRepository certificationJobRepository;
     private final CertificationRepositoryCustomImpl certificationRepositoryCustomImpl;
     private final UserService userService;
+    private final FavoriteRepository favoriteRepository;
 
 
     @Cacheable(
@@ -191,6 +196,38 @@ public class CertificationService {
 
         return CertificationListResponse.of(certificationSimpleList);
 
+    }
+
+    public List<CertificationRankResponse> getCertificationJob(final Long userId){
+        User user = userService.getUser(userId);
+        String jobName = userService.getUserJob(userId).jobList().get(0);
+        Job job = jobRepository.findByName(jobName)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.JOB_NOT_FOUND));
+
+        Pageable top3 = PageRequest.of(0, 3);
+        List<Certification> certList =
+            favoriteRepository.findTopByJobOrderByFavoriteCount(job.getId(), top3);
+
+        AtomicInteger rank = new AtomicInteger(1);
+
+        return certList.stream()
+            .map(cert -> new CertificationRankResponse(rank.getAndIncrement(), cert))
+            .toList();
+    }
+
+    public List<CertificationRankResponse> getCertificationTrack(final Long userId){
+        User user = userService.getUser(userId);
+        TrackType trackType = user.getTrack();
+
+        Pageable top3 = PageRequest.of(0, 3);
+
+        List<Certification> certificationList = favoriteRepository.findTopCertificationsByTrack(trackType, top3);
+
+        AtomicInteger rank = new AtomicInteger(1);
+
+        return certificationList.stream()
+            .map(c -> new CertificationRankResponse(rank.getAndIncrement(), c))
+            .toList();
     }
 
 }

--- a/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
@@ -17,15 +17,19 @@ import org.sopt.certi_server.domain.job.repository.JobRepository;
 import org.sopt.certi_server.domain.major.entity.Major;
 import org.sopt.certi_server.domain.major.repository.MajorRepository;
 import org.sopt.certi_server.domain.user.entity.User;
+import org.sopt.certi_server.domain.user.entity.enums.TrackType;
 import org.sopt.certi_server.domain.user.service.UserService;
 import org.sopt.certi_server.global.error.code.ErrorCode;
 import org.sopt.certi_server.global.error.exception.NotFoundException;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -45,6 +49,7 @@ public class CertificationService {
     private final CertificationJobRepository certificationJobRepository;
     private final CertificationRepositoryCustomImpl certificationRepositoryCustomImpl;
     private final UserService userService;
+    private final FavoriteRepository favoriteRepository;
 
 
     @Cacheable(
@@ -195,6 +200,38 @@ public class CertificationService {
 
         return CertificationListResponse.of(certificationSimpleList);
 
+    }
+
+    public List<CertificationRankResponse> getCertificationJob(final Long userId){
+        User user = userService.getUser(userId);
+        String jobName = userService.getUserJob(userId).jobList().get(0);
+        Job job = jobRepository.findByName(jobName)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.JOB_NOT_FOUND));
+
+        Pageable top3 = PageRequest.of(0, 3);
+        List<Certification> certList =
+            favoriteRepository.findTopByJobOrderByFavoriteCount(job.getId(), top3);
+
+        AtomicInteger rank = new AtomicInteger(1);
+
+        return certList.stream()
+            .map(cert -> new CertificationRankResponse(rank.getAndIncrement(), cert))
+            .toList();
+    }
+
+    public List<CertificationRankResponse> getCertificationTrack(final Long userId){
+        User user = userService.getUser(userId);
+        TrackType trackType = user.getTrack();
+
+        Pageable top3 = PageRequest.of(0, 3);
+
+        List<Certification> certificationList = favoriteRepository.findTopCertificationsByTrack(trackType, top3);
+
+        AtomicInteger rank = new AtomicInteger(1);
+
+        return certificationList.stream()
+            .map(c -> new CertificationRankResponse(rank.getAndIncrement(), c))
+            .toList();
     }
 
 }

--- a/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
@@ -204,7 +204,11 @@ public class CertificationService {
 
     public List<CertificationRankResponse> getCertificationJob(final Long userId){
         User user = userService.getUser(userId);
-        String jobName = userService.getUserJob(userId).jobList().get(0);
+        List<String> jobList = userService.getUserJob(userId).jobList();
+        if (jobList.isEmpty()) {
+            throw new NotFoundException(ErrorCode.JOB_NOT_FOUND);
+        }
+        String jobName = jobList.get(0);
         Job job = jobRepository.findByName(jobName)
             .orElseThrow(() -> new NotFoundException(ErrorCode.JOB_NOT_FOUND));
 

--- a/src/main/java/org/sopt/certi_server/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/favorite/repository/FavoriteRepository.java
@@ -3,8 +3,11 @@ package org.sopt.certi_server.domain.favorite.repository;
 import org.sopt.certi_server.domain.certification.entity.Certification;
 import org.sopt.certi_server.domain.favorite.entity.Favorite;
 import org.sopt.certi_server.domain.user.entity.User;
+import org.sopt.certi_server.domain.user.entity.enums.TrackType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -29,4 +32,32 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     boolean existsByUserAndCertification(User user, Certification certification);
 
 	void deleteAllByUser(User user);
+
+    @Query("""
+        select c
+        from Favorite f
+            join f.certification c
+            join CertificationJob cj on cj.certification = c
+        where cj.job.id = :jobId
+        group by c, cj.weight
+        order by count(f) desc, cj.weight desc
+        """)
+    List<Certification> findTopByJobOrderByFavoriteCount(
+        @Param("jobId") Long jobId,
+        Pageable pageable
+    );
+
+    @Query("""
+        select c
+        from Favorite f
+            join f.certification c
+            join f.user u
+        where u.track = :track
+        group by c
+        order by count(f) desc
+        """)
+    List<Certification> findTopCertificationsByTrack(
+        @Param("track") TrackType track,
+        Pageable pageable
+    );
 }

--- a/src/main/java/org/sopt/certi_server/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/favorite/repository/FavoriteRepository.java
@@ -34,13 +34,13 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 	void deleteAllByUser(User user);
 
     @Query("""
-        select c
+        select distinct c
         from Favorite f
             join f.certification c
             join CertificationJob cj on cj.certification = c
         where cj.job.id = :jobId
-        group by c, cj.weight
-        order by count(f) desc, cj.weight desc
+        group by c
+        order by count(f) desc, max(cj.weight) desc
         """)
     List<Certification> findTopByJobOrderByFavoriteCount(
         @Param("jobId") Long jobId,


### PR DESCRIPTION
## 📣 Related Issue


- close #171 

## 📝 Summary

- 추천 자격증 조회 시 변경 사항 반영
- 직무별/계열별 Top3자격증 조회 API 구현

## 🙏 Question & PR point

- 현재 직무의 순위가 반영되지 않은 상태로 구현을 하였어서 추후에 성민님의 PR 반영 및 충돌 해결 후 직무의 순위를 반영해서 약간의 수정이 필요할 것 같습니다
- 3순위 조회 시 JPQL을 사용하여서 limit 3이 적용이 안 되어 Pageable을 사용하였는데 JPQL을 그대로 가져갈지 QueryDSL을 쓰는 게 나을지 성민님의 의견이 궁금합니다!




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 직무별 상위 자격증(Top3) 조회 기능이 추가되었습니다.
  * 트랙별 상위 자격증(Top3) 조회 기능이 추가되었습니다.
  * 자격증 응답에 순위 정보가 포함됩니다.
  * 자격증 정보에 설명(description) 필드가 추가되어 상세 내용을 제공합니다.

* **잡무/인프라**
  * CI/CD 워크플로우의 도커 이미지 태그가 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->