### PR TITLE
Feat/#174 계열별/직무별 자격증 리스트 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/certification/controller/CertificationController.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/controller/CertificationController.java
@@ -62,16 +62,28 @@ public class CertificationController {
         }
     }
 
-    @GetMapping
-    @Operation(summary = "카테고리별 자격증 조회 API", description = "카테고리별로 자격증을 조회합니다")
-    public ResponseEntity<SuccessResponse<?>> getCertificationList(
+    @GetMapping("/jobs")
+    @Operation(summary = "직무별 자격증 조회 API", description = "직무별로 자격증 리스트를 조회합니다")
+    public ResponseEntity<SuccessResponse<?>> getCertificationByJobList(
             @AuthenticationPrincipal Long userId,
             @RequestParam(value = "isFavorite") Boolean isFavorite,
             @RequestParam(value = "jobs") String job
     ) {
-        CertificationListResponse certificationListResponse = certificationService.getCertificationList(userId, isFavorite, job);
+        CertificationListResponse certificationListResponse = certificationService.getCertificationByJobList(userId, isFavorite, job);
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, certificationListResponse));
     }
+
+    @GetMapping("/tracks")
+    @Operation(summary = "계열별 자격증 조회 API", description = "계열별 자격증 리스트를 조회합니다")
+    public ResponseEntity<SuccessResponse<?>> getCertificationByTrackList(
+        @AuthenticationPrincipal Long userId,
+        @RequestParam(value = "isFavorite") Boolean isFavorite,
+        @RequestParam(value = "tracks") String track
+    ) {
+        CertificationListResponse certificationListResponse = certificationService.getCertificationByTrackList(userId, isFavorite, track);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, certificationListResponse));
+    }
+
 
     @GetMapping("/recommend")
     @Operation(summary = "자격증 추천 API", description = "추천 자격증을 조회합니다")
@@ -100,6 +112,8 @@ public class CertificationController {
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, certificationRankResponseList));
 
     }
+
+
 
 
 }

--- a/src/main/java/org/sopt/certi_server/domain/certification/entity/CertificationTrack.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/entity/CertificationTrack.java
@@ -1,0 +1,33 @@
+package org.sopt.certi_server.domain.certification.entity;
+
+import org.sopt.certi_server.domain.user.entity.enums.TrackType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(name = "certification_track_map",
+	uniqueConstraints = @UniqueConstraint(columnNames = {"certification_id", "track"}))
+public class CertificationTrack {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "certification_id", nullable = false)
+	private Certification certification;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "track", nullable = false)
+	private TrackType track;
+}

--- a/src/main/java/org/sopt/certi_server/domain/certification/entity/CertificationTrack.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/entity/CertificationTrack.java
@@ -14,7 +14,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 @Table(name = "certification_track_map",
 	uniqueConstraints = @UniqueConstraint(columnNames = {"certification_id", "track"}))

--- a/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationRepositoryCustom.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationRepositoryCustom.java
@@ -2,9 +2,13 @@ package org.sopt.certi_server.domain.certification.repository;
 
 import org.sopt.certi_server.domain.certification.dto.response.CertificationSimple;
 import org.sopt.certi_server.domain.user.entity.User;
+import org.sopt.certi_server.domain.user.entity.enums.TrackType;
 
 import java.util.List;
 
 public interface CertificationRepositoryCustom {
     List<CertificationSimple> findByJobAndFavorite(User user, boolean isFavorite, Long jobId);
+
+    List<CertificationSimple> findByTrackAndFavorite(User user, boolean isFavorite, TrackType track);
+
 }

--- a/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationRepositoryCustomImpl.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/repository/CertificationRepositoryCustomImpl.java
@@ -8,8 +8,10 @@ import org.sopt.certi_server.domain.certification.dto.response.CertificationSimp
 import org.sopt.certi_server.domain.certification.entity.Certification;
 import org.sopt.certi_server.domain.certification.entity.QCertification;
 import org.sopt.certi_server.domain.certification.entity.QCertificationJob;
+import org.sopt.certi_server.domain.certification.entity.QCertificationTrack;
 import org.sopt.certi_server.domain.favorite.entity.QFavorite;
 import org.sopt.certi_server.domain.user.entity.User;
+import org.sopt.certi_server.domain.user.entity.enums.TrackType;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -52,5 +54,38 @@ public class CertificationRepositoryCustomImpl implements CertificationRepositor
                 })
                 .filter(Objects::nonNull)
                 .toList();
+    }
+
+    @Override
+    public List<CertificationSimple> findByTrackAndFavorite(User user, boolean isFavorite, TrackType track) {
+        QCertification certification = QCertification.certification;
+        QFavorite favorite = QFavorite.favorite;
+        QCertificationTrack certificationTrack = QCertificationTrack.certificationTrack;
+
+        List<Tuple> results = jpaQueryFactory
+            .select(certification, favorite)
+            .from(certification)
+            .leftJoin(favorite)
+            .on(favorite.user.eq(user)
+                .and(favorite.certification.eq(certification)))
+            .join(certificationTrack)
+            .on(certificationTrack.certification.eq(certification))
+            .where(
+                certificationTrack.track.eq(track),
+                isFavorite ? favorite.isNotNull() : null
+            )
+            .orderBy(certification.id.desc())
+            .fetch();
+
+        return results.stream()
+            .map(tuple -> {
+                Certification findCertification = tuple.get(certification);
+                boolean fav = tuple.get(favorite) != null;
+
+                if (findCertification == null) return null;
+                return new CertificationSimple(findCertification, fav);
+            })
+            .filter(Objects::nonNull)
+            .toList();
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/service/CertificationService.java
@@ -191,7 +191,7 @@ public class CertificationService {
     }
 
 
-    public CertificationListResponse getCertificationList(final Long userId, final boolean isFavorite, final String jobName) {
+    public CertificationListResponse getCertificationByJobList(final Long userId, final boolean isFavorite, final String jobName) {
         User user = userService.getUser(userId);
         Job job = jobRepository.findByName(jobName)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.JOB_NOT_FOUND));
@@ -201,6 +201,19 @@ public class CertificationService {
         return CertificationListResponse.of(certificationSimpleList);
 
     }
+
+    public CertificationListResponse getCertificationByTrackList(final Long userId, final boolean isFavorite, final String track) {
+        User user = userService.getUser(userId);
+
+        TrackType trackType = TrackType.from(track);
+
+        List<CertificationSimple> certificationSimpleList =
+            certificationRepositoryCustomImpl.findByTrackAndFavorite(user, isFavorite, trackType);
+
+        return CertificationListResponse.of(certificationSimpleList);
+    }
+
+
 
     public List<CertificationRankResponse> getCertificationJob(final Long userId){
         User user = userService.getUser(userId);


### PR DESCRIPTION
## 📣 Related Issue

- close #174 

## 📝 Summary

- [ ] 직무별 자격증 리스트 조회 API
- [ ] 계열별 자격증 리스트 조회 API

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 진로(Track) 기반 자격증 검색 및 필터링 기능이 추가되었습니다.
  * 즐겨찾기 필터와 함께 진로별 자격증 목록을 조회할 수 있습니다.

* **개선사항**
  * 직무별 자격증 조회가 별도 기능으로 분리되어 명확해졌습니다.
  * 자격증과 진로 간 연관 구조가 강화되어 조회 정확도가 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->