### PR TITLE
#177 [Fix] 사용자 계열 정보 반환 API 추가, 회원 탈퇴 API 수정

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/certification/controller/CertificationController.java
+++ b/src/main/java/org/sopt/certi_server/domain/certification/controller/CertificationController.java
@@ -64,7 +64,7 @@ public class CertificationController {
 
     @GetMapping("/jobs")
     @Operation(summary = "직무별 자격증 조회 API", description = "직무별로 자격증 리스트를 조회합니다")
-    public ResponseEntity<SuccessResponse<?>> getCertificationByJobList(
+    public ResponseEntity<SuccessResponse<CertificationListResponse>> getCertificationByJobList(
             @AuthenticationPrincipal Long userId,
             @RequestParam(value = "isFavorite") Boolean isFavorite,
             @RequestParam(value = "jobs") String job
@@ -75,7 +75,7 @@ public class CertificationController {
 
     @GetMapping("/tracks")
     @Operation(summary = "계열별 자격증 조회 API", description = "계열별 자격증 리스트를 조회합니다")
-    public ResponseEntity<SuccessResponse<?>> getCertificationByTrackList(
+    public ResponseEntity<SuccessResponse<CertificationListResponse>> getCertificationByTrackList(
         @AuthenticationPrincipal Long userId,
         @RequestParam(value = "isFavorite") Boolean isFavorite,
         @RequestParam(value = "tracks") String track

--- a/src/main/java/org/sopt/certi_server/domain/comment/repository/CertificationCommentLikeRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/comment/repository/CertificationCommentLikeRepository.java
@@ -42,4 +42,6 @@ public interface CertificationCommentLikeRepository extends JpaRepository<Certif
             @Param("user") User user,
             @Param("certification") Certification certification
     );
+
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/org/sopt/certi_server/domain/comment/repository/CertificationCommentRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/comment/repository/CertificationCommentRepository.java
@@ -2,6 +2,7 @@ package org.sopt.certi_server.domain.comment.repository;
 
 
 import org.sopt.certi_server.domain.comment.entity.CertificationComment;
+import org.sopt.certi_server.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -33,4 +34,6 @@ public interface CertificationCommentRepository extends JpaRepository<Certificat
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE CertificationComment c SET c.likeCount = c.likeCount - 1 WHERE c.id = :commentId")
     void decrementLikeCount(@Param("commentId") Long commentId);
+
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/controller/AuthController.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/controller/AuthController.java
@@ -85,7 +85,7 @@ public class AuthController {
 
     @DeleteMapping("/withdraw")
     @Operation(summary = "회원탈퇴 API", description = "회원 탈퇴를 진행합니다")
-    public ResponseEntity<SuccessResponse> withdraw(
+    public ResponseEntity<SuccessResponse<Void>> withdraw(
         @AuthenticationPrincipal Long userId
     ){
         authService.withdraw(userId);

--- a/src/main/java/org/sopt/certi_server/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/controller/UserController.java
@@ -78,7 +78,7 @@ public class UserController {
 
     @PostMapping("/job")
     @Operation(summary = "희망직무 수정 API", description = "사용자의 희망직무를 수정합니다.")
-    public ResponseEntity<SuccessResponse> updateUserJob(
+    public ResponseEntity<SuccessResponse<Void>> updateUserJob(
             @AuthenticationPrincipal Long userId,
             @RequestBody UpdateJobRequest updateJobRequest
     ) {
@@ -113,5 +113,13 @@ public class UserController {
     ){
         userService.changeMajor(userId, request.majorName());
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_UPDATE));
+    }
+
+    @GetMapping(value = "/track")
+    @Operation(summary = "계열 조회 API", description = "계열 정보를 반환합니다.")
+    public ResponseEntity<SuccessResponse<GetTrackResponse>> getUserTrack(
+            @AuthenticationPrincipal Long userId
+    ){
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, userService.getTrack(userId)));
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/response/GetTrackResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/response/GetTrackResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.certi_server.domain.user.dto.response;
+
+import org.sopt.certi_server.domain.user.entity.enums.TrackType;
+
+public record GetTrackResponse(TrackType track) {
+    public static GetTrackResponse of(TrackType track){
+        return new GetTrackResponse(track);
+    }
+}

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/response/GetTrackResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/response/GetTrackResponse.java
@@ -2,8 +2,8 @@ package org.sopt.certi_server.domain.user.dto.response;
 
 import org.sopt.certi_server.domain.user.entity.enums.TrackType;
 
-public record GetTrackResponse(TrackType track) {
+public record GetTrackResponse(String track) {
     public static GetTrackResponse of(TrackType track){
-        return new GetTrackResponse(track);
+        return new GetTrackResponse(track.getName());
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/service/AuthService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/AuthService.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.sopt.certi_server.domain.acquisition.repository.AcquisitionRepository;
 import org.sopt.certi_server.domain.activity.repository.ActivityRepository;
+import org.sopt.certi_server.domain.comment.repository.CertificationCommentLikeRepository;
+import org.sopt.certi_server.domain.comment.repository.CertificationCommentRepository;
 import org.sopt.certi_server.domain.favorite.repository.FavoriteRepository;
 import org.sopt.certi_server.domain.job.entity.Job;
 import org.sopt.certi_server.domain.job.repository.JobRepository;
@@ -55,6 +57,8 @@ public class AuthService {
     private final FavoriteRepository favoriteRepository;
     private final CareerRepository careerRepository;
     private final ActivityRepository activityRepository;
+    private final CertificationCommentRepository certificationCommentRepository;
+    private final CertificationCommentLikeRepository certificationCommentLikeRepository;
 
     public AuthResponse login(OAuthUserInformation userInfo) {
         return userRepository.findBySocialTypeAndSocialId(userInfo.socialType(), userInfo.socialId())
@@ -141,6 +145,12 @@ public class AuthService {
     @Transactional
     public void withdraw(final Long userId){
         User user = userService.getUser(userId);
+
+        //좋아요 삭제
+        certificationCommentLikeRepository.deleteAllByUser(user);
+
+        //댓글 삭제
+        certificationCommentRepository.deleteAllByUser(user);
 
         //희망 직무 삭제
         userJobRepository.deleteAllByUser(user);

--- a/src/main/java/org/sopt/certi_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/UserService.java
@@ -10,10 +10,7 @@ import org.sopt.certi_server.domain.job.repository.JobRepository;
 import org.sopt.certi_server.domain.major.entity.MajorImpl;
 import org.sopt.certi_server.domain.major.repository.MajorImplRepository;
 import org.sopt.certi_server.domain.user.dto.request.UpdateUserRequest;
-import org.sopt.certi_server.domain.user.dto.response.GetJobResponse;
-import org.sopt.certi_server.domain.user.dto.response.GetMyPageInfoResponse;
-import org.sopt.certi_server.domain.user.dto.response.GetUserResponse;
-import org.sopt.certi_server.domain.user.dto.response.PersonalInformationResponse;
+import org.sopt.certi_server.domain.user.dto.response.*;
 import org.sopt.certi_server.domain.user.entity.University;
 import org.sopt.certi_server.domain.user.entity.User;
 import org.sopt.certi_server.domain.user.entity.UserJob;
@@ -210,4 +207,10 @@ public class UserService {
 
         user.changeMajor(mi);
     }
+
+    public GetTrackResponse getTrack(Long userId) {
+        User user = getUser(userId);
+        return GetTrackResponse.of(user.getTrack());
+    }
+
 }


### PR DESCRIPTION
## 📣 Related Issue

- close #177 

## 📝 Summary

- 사용자 계열 정보 반환 API 추가
- 회원 탈퇴 API 수정

## 🙏 Question & PR point

- N/A

## 📬 Postman

- N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 사용자 트랙 정보 조회 API 추가

* **개선 사항**
  * 인증·사용자 관련 응답의 페이로드 형식 일관성 개선으로 결과가 더 명확해짐
  * 회원 탈퇴 시 인증 댓글과 댓글 좋아요를 포함한 데이터 정리 강화로 개인정보 제거 범위 확대

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->