### PR TITLE
Feat/#179 월별/일별 자격증 조회 API 구현(캘린더 뷰)

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/controller/UserPreCertificationController.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/controller/UserPreCertificationController.java
@@ -1,5 +1,7 @@
 package org.sopt.certi_server.domain.userprecertification.controller;
 
+import java.time.LocalDate;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -7,11 +9,14 @@ import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.sopt.certi_server.domain.userprecertification.dto.request.CreateUserPreCertificationRequest;
 import org.sopt.certi_server.domain.userprecertification.dto.request.PatchPreCertificationRequest;
+import org.sopt.certi_server.domain.userprecertification.dto.response.DayScheduleRes;
+import org.sopt.certi_server.domain.userprecertification.dto.response.MonthCalendarRes;
 import org.sopt.certi_server.domain.userprecertification.dto.response.PreCertificationSimple;
 import org.sopt.certi_server.domain.userprecertification.dto.response.PreCertificationSimpleListResponse;
 import org.sopt.certi_server.domain.userprecertification.service.UserPreCertificationService;
 import org.sopt.certi_server.global.error.code.SuccessCode;
 import org.sopt.certi_server.global.error.dto.SuccessResponse;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -63,5 +68,26 @@ public class UserPreCertificationController {
     ) {
         userPreCertificationService.deletePreCertification(userId, certificationId);
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_DELETE));
+    }
+
+    @GetMapping("/month")
+    @Operation(summary = "월별 취득예정 자격증 조회", description = "캘린더에서 월별 취득예정 자격증을 조회합니다")
+    public ResponseEntity<SuccessResponse<MonthCalendarRes>> getMonth(
+        @AuthenticationPrincipal Long userId,
+        @RequestParam(required = true) int year,
+        @RequestParam(required = true) int month
+    ){
+        MonthCalendarRes monthCalendarRes = userPreCertificationService.getMonthCalendar(userId, year, month);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, monthCalendarRes));
+    }
+
+    @GetMapping("/day")
+    @Operation(summary = "일별 취득예정 자격증 조회", description = "캘린더에서 일별 취득예정 자격증을 조회합니다")
+    public ResponseEntity<SuccessResponse<DayScheduleRes>> getDay(
+        @AuthenticationPrincipal Long userId,
+        @RequestParam(required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ){
+        DayScheduleRes dayScheduleRes = userPreCertificationService.getDaySchedules(userId, date);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, dayScheduleRes));
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/dto/response/DayDotRes.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/dto/response/DayDotRes.java
@@ -1,0 +1,6 @@
+package org.sopt.certi_server.domain.userprecertification.dto.response;
+
+public record DayDotRes(
+	Integer day,
+	Long count
+) {}

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/dto/response/DayScheduleRes.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/dto/response/DayScheduleRes.java
@@ -1,0 +1,9 @@
+package org.sopt.certi_server.domain.userprecertification.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record DayScheduleRes(
+	LocalDate date,
+	List<ScheduleICertificationRes> items // 없으면 null
+) {}

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/dto/response/MonthCalendarRes.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/dto/response/MonthCalendarRes.java
@@ -1,0 +1,11 @@
+package org.sopt.certi_server.domain.userprecertification.dto.response;
+
+import java.util.List;
+
+public record MonthCalendarRes(
+	int year,
+	int month,
+	List<DayDotRes> days
+) {
+}
+

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/dto/response/ScheduleICertificationRes.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/dto/response/ScheduleICertificationRes.java
@@ -1,0 +1,11 @@
+package org.sopt.certi_server.domain.userprecertification.dto.response;
+
+public record ScheduleICertificationRes(
+	Long userPreCertificationId,
+	String certificationName,
+	String certificationType,
+	String description,
+	String location,
+	String time
+) {
+}

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/repository/UserPreCertificationRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/repository/UserPreCertificationRepository.java
@@ -2,11 +2,14 @@ package org.sopt.certi_server.domain.userprecertification.repository;
 
 import org.sopt.certi_server.domain.certification.entity.Certification;
 import org.sopt.certi_server.domain.user.entity.User;
+import org.sopt.certi_server.domain.userprecertification.dto.response.DayDotRes;
+import org.sopt.certi_server.domain.userprecertification.dto.response.MonthCalendarRes;
 import org.sopt.certi_server.domain.userprecertification.entity.UserPreCertification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -43,4 +46,38 @@ public interface UserPreCertificationRepository extends JpaRepository<UserPreCer
     );
 
     int countByUser(User user);
+
+    @Query("""
+    select function('day', upc.testDate) as day,
+           count(upc.id) as count
+    from UserPreCertification upc
+    where upc.user.id = :userId
+      and upc.testDate between :start and :end
+    group by function('day', upc.testDate)
+    order by function('day', upc.testDate) asc
+""")
+    List<DayDotProjection> findMonthDots(
+        @Param("userId") Long userId,
+        @Param("start") LocalDateTime start,
+        @Param("end") LocalDateTime end
+    );
+
+    @Query("""
+        select upc
+        from UserPreCertification upc
+        join fetch upc.certification c
+        where upc.user.id = :userId
+          and upc.testDate between :start and :end
+        order by upc.testDate asc
+    """)
+    List<UserPreCertification> findDayItems(
+        @Param("userId") Long userId,
+        @Param("start") LocalDateTime start,
+        @Param("end") LocalDateTime end
+    );
+
+    public interface DayDotProjection {
+        Integer getDay();
+        Long getCount();
+    }
 }

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/service/UserPreCertificationService.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/service/UserPreCertificationService.java
@@ -1,5 +1,9 @@
 package org.sopt.certi_server.domain.userprecertification.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.certi_server.domain.acquisition.repository.AcquisitionRepository;
@@ -9,8 +13,12 @@ import org.sopt.certi_server.domain.user.entity.User;
 import org.sopt.certi_server.domain.user.service.UserService;
 import org.sopt.certi_server.domain.userprecertification.dto.request.CreateUserPreCertificationRequest;
 import org.sopt.certi_server.domain.userprecertification.dto.request.PatchPreCertificationRequest;
+import org.sopt.certi_server.domain.userprecertification.dto.response.DayDotRes;
+import org.sopt.certi_server.domain.userprecertification.dto.response.DayScheduleRes;
+import org.sopt.certi_server.domain.userprecertification.dto.response.MonthCalendarRes;
 import org.sopt.certi_server.domain.userprecertification.dto.response.PreCertificationSimple;
 import org.sopt.certi_server.domain.userprecertification.dto.response.PreCertificationSimpleListResponse;
+import org.sopt.certi_server.domain.userprecertification.dto.response.ScheduleICertificationRes;
 import org.sopt.certi_server.domain.userprecertification.entity.Location;
 import org.sopt.certi_server.domain.userprecertification.entity.UserPreCertification;
 import org.sopt.certi_server.domain.userprecertification.entity.enums.IconType;
@@ -100,4 +108,61 @@ public class UserPreCertificationService {
                 request.testDate()
         );
     }
+
+    public MonthCalendarRes getMonthCalendar(Long userId, int year, int month) {
+        LocalDate first = LocalDate.of(year, month, 1);
+        LocalDate last = first.withDayOfMonth(first.lengthOfMonth());
+
+        LocalDateTime start = first.atStartOfDay();
+        LocalDateTime end = last.atTime(23, 59, 59);
+
+        List<DayDotRes> days = userPreCertificationRepository.findMonthDots(userId, start, end).stream()
+            .map(p -> new DayDotRes(p.getDay(), p.getCount()))
+            .toList();
+
+        // "아무것도 없으면 null" 요구사항 반영
+        List<DayDotRes> dayDotResList = days.isEmpty()
+            ? null
+            : days.stream().map(d -> new  DayDotRes(d.day(), d.count())).toList();
+
+        return new MonthCalendarRes(year, month, days);
+    }
+
+    public DayScheduleRes getDaySchedules(Long userId, LocalDate date) {
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = date.atTime(23, 59, 59);
+
+        List<UserPreCertification> list =
+            userPreCertificationRepository.findDayItems(userId, start, end);
+
+        List<ScheduleICertificationRes> items = list.isEmpty()
+            ? null
+            : list.stream().map(this::toScheduleItem).toList();
+
+        return new DayScheduleRes(date, items);
+    }
+
+    private ScheduleICertificationRes toScheduleItem(UserPreCertification upc) {
+
+        String certificationName = upc.getCertification().getName();
+        String certificationType = upc.getCertification().getCertificationType() == null
+            ? null
+            : upc.getCertification().getCertificationType().getKoreanName();
+
+        String description = upc.getCertification().getDescription();
+
+        String location = upc.getLocation() == null ? null : upc.getLocation().toString(); // Location 설계에 맞게 수정
+        String time = upc.getTestDate() == null ? null : upc.getTestDate().toString();
+
+        return new ScheduleICertificationRes(
+            upc.getId(),
+            certificationName,
+            certificationType,
+            description,
+            location,
+            time
+        );
+    }
+
+
 }

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/service/UserPreCertificationService.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/service/UserPreCertificationService.java
@@ -120,7 +120,6 @@ public class UserPreCertificationService {
             .map(p -> new DayDotRes(p.getDay(), p.getCount()))
             .toList();
 
-        // "아무것도 없으면 null" 요구사항 반영
         List<DayDotRes> dayDotResList = days.isEmpty()
             ? null
             : days.stream().map(d -> new  DayDotRes(d.day(), d.count())).toList();


### PR DESCRIPTION
## 📣 Related Issue

- close #179 

## 📝 Summary

- [ ] 월별 자격증 조회 API
- [ ] 일별 자격증 조회 API

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 월별 캘린더 조회 기능 추가: 특정 연도와 월의 인증 일정을 캘린더 형식으로 확인 가능
  * 일일 일정 조회 기능 추가: 특정 날짜의 상세 인증 일정(인증명, 유형, 설명, 장소, 시간)을 조회 가능
  * 사용자별 인증 일정 데이터 체계화: 월별 및 일별 단위로 효율적으로 일정 관리 가능

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->