### PR TITLE
Feat/#196 신고 API 구현

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/comment/entity/CertificationComment.java
+++ b/src/main/java/org/sopt/certi_server/domain/comment/entity/CertificationComment.java
@@ -41,7 +41,7 @@ public class CertificationComment extends BaseTimeEntity {
     @Column(name = "like_count")
     private Long likeCount = 0L;
 
-    @Column(name = "deleted_at", nullable = false)
+    @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
     @Builder

--- a/src/main/java/org/sopt/certi_server/domain/comment/entity/CertificationComment.java
+++ b/src/main/java/org/sopt/certi_server/domain/comment/entity/CertificationComment.java
@@ -1,10 +1,16 @@
 package org.sopt.certi_server.domain.comment.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 import org.sopt.certi_server.domain.certification.entity.Certification;
 import org.sopt.certi_server.domain.user.entity.User;
 import org.sopt.certi_server.global.entity.BaseTimeEntity;
@@ -13,6 +19,8 @@ import org.sopt.certi_server.global.entity.BaseTimeEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "certification_comment")
 @Getter
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE certification_comment SET deleted_at = NOW() WHERE certification_comment_id = ?")
 public class CertificationComment extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,6 +40,9 @@ public class CertificationComment extends BaseTimeEntity {
 
     @Column(name = "like_count")
     private Long likeCount = 0L;
+
+    @Column(name = "deleted_at", nullable = false)
+    private LocalDateTime deletedAt;
 
     @Builder
     private CertificationComment(User user, Certification certification, String content){

--- a/src/main/java/org/sopt/certi_server/domain/comment/service/CertificationCommentService.java
+++ b/src/main/java/org/sopt/certi_server/domain/comment/service/CertificationCommentService.java
@@ -210,4 +210,9 @@ public class CertificationCommentService {
             certificationCommentRepository.incrementLikeCount(commentId);
         }
     }
+
+    public CertificationComment getComment(Long commentId){
+        return certificationCommentRepository.findById(commentId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+    }
 }

--- a/src/main/java/org/sopt/certi_server/domain/report/controller/ReportController.java
+++ b/src/main/java/org/sopt/certi_server/domain/report/controller/ReportController.java
@@ -1,0 +1,40 @@
+package org.sopt.certi_server.domain.report.controller;
+
+import org.sopt.certi_server.domain.report.service.ReportService;
+import org.sopt.certi_server.global.error.code.SuccessCode;
+import org.sopt.certi_server.global.error.dto.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/report")
+@Tag(name = "Report 컨트롤러", description = "신고와 관련된 API를 처리합니다.")
+public class ReportController {
+	private final ReportService reportService;
+
+	@PostMapping("/comment/{certification_comment_id}")
+	@Operation(summary = "댓글 신고 API", description = "댓글을 신고합니다")
+	public ResponseEntity<SuccessResponse<Void>> reportComment(
+		@Parameter(
+			name = "certification_comment_id",
+			description = "신고할 댓글 ID",
+			example = "1",
+			required = true
+		)
+		@PathVariable(name = "certification_comment_id") Long commentId,
+		@AuthenticationPrincipal Long userId
+	){
+		reportService.createCommentReport(userId, commentId);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+	}
+}

--- a/src/main/java/org/sopt/certi_server/domain/report/entity/CommentReport.java
+++ b/src/main/java/org/sopt/certi_server/domain/report/entity/CommentReport.java
@@ -1,0 +1,51 @@
+package org.sopt.certi_server.domain.report.entity;
+
+import org.sopt.certi_server.domain.comment.entity.CertificationComment;
+import org.sopt.certi_server.domain.user.entity.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_user_comment",
+			columnNames = {"certification_comment_id", "user_id"}
+		)
+	}
+)
+@Getter
+public class CommentReport {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(targetEntity = CertificationComment.class, fetch = FetchType.LAZY)
+	@JoinColumn(name = "certification_comment_id", nullable = false)
+	private CertificationComment certificationComment;
+
+	@ManyToOne(targetEntity = User.class, fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	public CommentReport(CertificationComment certificationComment, User user) {
+		this.certificationComment = certificationComment;
+		this.user = user;
+	}
+
+	public static CommentReport createCommentReport(final CertificationComment certificationComment, final User user) {
+		return new CommentReport(certificationComment, user);
+	}
+}

--- a/src/main/java/org/sopt/certi_server/domain/report/repository/ReportRepository.java
+++ b/src/main/java/org/sopt/certi_server/domain/report/repository/ReportRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.certi_server.domain.report.repository;
+
+import org.sopt.certi_server.domain.report.entity.CommentReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReportRepository extends JpaRepository<CommentReport, Long> {
+}

--- a/src/main/java/org/sopt/certi_server/domain/report/service/ReportService.java
+++ b/src/main/java/org/sopt/certi_server/domain/report/service/ReportService.java
@@ -1,0 +1,38 @@
+package org.sopt.certi_server.domain.report.service;
+
+import org.sopt.certi_server.domain.comment.entity.CertificationComment;
+import org.sopt.certi_server.domain.comment.service.CertificationCommentService;
+import org.sopt.certi_server.domain.report.entity.CommentReport;
+import org.sopt.certi_server.domain.report.repository.ReportRepository;
+import org.sopt.certi_server.domain.user.entity.User;
+import org.sopt.certi_server.domain.user.service.UserService;
+import org.sopt.certi_server.global.discord.dto.DiscordWebhookEvent;
+import org.sopt.certi_server.global.discord.dto.MessageFormatter;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportService {
+	private final ReportRepository reportRepository;
+	private final CertificationCommentService certificationCommentService;
+	private final UserService userService;
+	private final ApplicationEventPublisher eventPublisher;
+
+	@Transactional
+	public void createCommentReport(final Long userId, final Long commentId) {
+		User user = userService.getUser(userId);
+		CertificationComment comment = certificationCommentService.getComment(commentId);
+		CommentReport report = CommentReport.createCommentReport(comment, user);
+		reportRepository.save(report);
+
+		String message = MessageFormatter.formatCommentReport(report);
+
+
+		eventPublisher.publishEvent(new DiscordWebhookEvent(message));
+	}
+}

--- a/src/main/java/org/sopt/certi_server/global/client/discord/DiscordWebhookClient.java
+++ b/src/main/java/org/sopt/certi_server/global/client/discord/DiscordWebhookClient.java
@@ -1,0 +1,16 @@
+package org.sopt.certi_server.global.client.discord;
+
+import org.sopt.certi_server.global.discord.dto.DiscordWebhookEvent;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(
+	name = "discordwebhookClient",
+	url = "${discord.webhook-url}"
+)
+public interface DiscordWebhookClient {
+	@PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+	void send(@RequestBody DiscordWebhookEvent message);
+}

--- a/src/main/java/org/sopt/certi_server/global/config/AsyncConfig.java
+++ b/src/main/java/org/sopt/certi_server/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package org.sopt.certi_server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/org/sopt/certi_server/global/discord/dto/DiscordWebhookEvent.java
+++ b/src/main/java/org/sopt/certi_server/global/discord/dto/DiscordWebhookEvent.java
@@ -1,0 +1,6 @@
+package org.sopt.certi_server.global.discord.dto;
+
+public record DiscordWebhookEvent(
+	String content
+) {
+}

--- a/src/main/java/org/sopt/certi_server/global/discord/dto/MessageFormatter.java
+++ b/src/main/java/org/sopt/certi_server/global/discord/dto/MessageFormatter.java
@@ -1,0 +1,38 @@
+package org.sopt.certi_server.global.discord.dto;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.sopt.certi_server.domain.comment.entity.CertificationComment;
+import org.sopt.certi_server.domain.report.entity.CommentReport;
+import org.sopt.certi_server.domain.user.entity.User;
+
+public class MessageFormatter {
+
+	private static final String COMMENT_REPORT_MESSAGE =
+		"```[%s] 댓글 %d 신고가 접수되었습니다.\n\n" +
+			"[신고자]\n" +
+			"유저 아이디 : %d\n" +
+			"유저 닉네임 : %s\n\n" +
+			"[신고된 댓글 작성자]\n" +
+			"유저 아이디 : %d\n" +
+			"유저 닉네임 : %s\n\n" +
+			"[신고된 댓글 내용]\n%s\n```";
+
+	public static String formatCommentReport(CommentReport report) {
+		CertificationComment comment = report.getCertificationComment();
+		User reporter = report.getUser();
+		User commentWriter = comment.getUser();
+
+		return String.format(
+			COMMENT_REPORT_MESSAGE,
+			LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+			comment.getId(),
+			reporter.getId(),
+			reporter.getNickname(),
+			commentWriter.getId(),
+			commentWriter.getNickname(),
+			comment.getContent()
+		);
+	}
+}

--- a/src/main/java/org/sopt/certi_server/global/discord/dto/MessageFormatter.java
+++ b/src/main/java/org/sopt/certi_server/global/discord/dto/MessageFormatter.java
@@ -15,7 +15,7 @@ public class MessageFormatter {
 			"유저 아이디 : %d\n" +
 			"유저 닉네임 : %s\n\n" +
 			"[신고된 댓글 작성자]\n" +
-			"유저 아이디 : %d\n" +
+			"유저 아이디 : %s\n" +
 			"유저 닉네임 : %s\n\n" +
 			"[신고된 댓글 내용]\n%s\n```";
 
@@ -23,6 +23,9 @@ public class MessageFormatter {
 		CertificationComment comment = report.getCertificationComment();
 		User reporter = report.getUser();
 		User commentWriter = comment.getUser();
+		String commentWriterId = (commentWriter != null) ? String.valueOf(commentWriter.getId()) : "알수없음";
+		String commentWriterNickname = (commentWriter != null) ? commentWriter.getNickname() : "탈퇴한 사용자";
+		String content = (comment.getContent() != null) ? comment.getContent() : "(삭제된 댓글)";
 
 		return String.format(
 			COMMENT_REPORT_MESSAGE,
@@ -30,9 +33,9 @@ public class MessageFormatter {
 			comment.getId(),
 			reporter.getId(),
 			reporter.getNickname(),
-			commentWriter.getId(),
-			commentWriter.getNickname(),
-			comment.getContent()
+			commentWriterId,
+			commentWriterNickname,
+			content
 		);
 	}
 }

--- a/src/main/java/org/sopt/certi_server/global/discord/service/DiscordService.java
+++ b/src/main/java/org/sopt/certi_server/global/discord/service/DiscordService.java
@@ -1,0 +1,29 @@
+package org.sopt.certi_server.global.discord.service;
+
+import org.sopt.certi_server.global.client.discord.DiscordWebhookClient;
+import org.sopt.certi_server.global.discord.dto.DiscordWebhookEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DiscordService {
+
+	private final DiscordWebhookClient discordWebhookClient;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void sendDiscordWebhookMessage(DiscordWebhookEvent message) {
+		try{
+			discordWebhookClient.send(message);
+		} catch (Exception e){
+			log.error(e.getMessage());
+		}
+	}
+}


### PR DESCRIPTION
## 📣 Related Issue


- close #196 

## 📝 Summary

- [x] 비동기 이벤트 기반으로 신고 시 디스코드 메시지 발송 구현
- [x] 댓글 soft delete 구현

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/b4785496-8fa2-4ff9-a794-6c25e8682e78" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 댓글 신고 API 및 신고 등록 기능 추가
  * 신고 발생 시 관리자에게 Discord 웹훅으로 알림 전송

* **개선 사항**
  * 댓글의 논리적 삭제(삭제 시 데이터 보존 및 표시 제외) 도입으로 데이터 안전성 향상
  * 댓글 조회용 보조 메서드 추가로 신고·조회 흐름 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->