### PR TITLE
#206 [fix] 구글 로그인 오류 해결, 취득 예정 리스트 조회 dto 필드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,9 @@ dependencies {
 
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.37.3'
 
+	// id 토큰 복호화를 위한 구글 api 클라이언트 라이브러리
+	implementation 'com.google.api-client:google-api-client:2.2.0'
+
 }
 
 
@@ -117,4 +120,5 @@ clean {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
 

--- a/src/main/java/org/sopt/certi_server/domain/comment/controller/CertificationCommentController.java
+++ b/src/main/java/org/sopt/certi_server/domain/comment/controller/CertificationCommentController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.sopt.certi_server.domain.comment.dto.request.CommentRegisterRequest;
 import org.sopt.certi_server.domain.comment.dto.response.CertificationCommentResponse;
+import org.sopt.certi_server.domain.comment.dto.response.CommentCreateResponse;
 import org.sopt.certi_server.domain.comment.service.CertificationCommentService;
 import org.sopt.certi_server.global.error.code.SuccessCode;
 import org.sopt.certi_server.global.error.dto.PageResponse;
@@ -27,12 +28,11 @@ public class CertificationCommentController {
 
     @PostMapping
     @Operation(summary = "댓글 등록 API", description = "댓글을 등록합니다.")
-    public ResponseEntity<SuccessResponse<Void>> registerCertificationComment(
+    public ResponseEntity<SuccessResponse<CommentCreateResponse>> registerCertificationComment(
             @RequestBody CommentRegisterRequest commentRegisterRequest,
             @AuthenticationPrincipal Long userId
     ){
-        certificationCommentService.registerComment(userId, commentRegisterRequest);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE, certificationCommentService.registerComment(userId, commentRegisterRequest)));
     }
 
     @DeleteMapping(value = "/{commentId}")

--- a/src/main/java/org/sopt/certi_server/domain/comment/dto/response/CommentCreateResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/comment/dto/response/CommentCreateResponse.java
@@ -1,0 +1,6 @@
+package org.sopt.certi_server.domain.comment.dto.response;
+
+public record CommentCreateResponse(
+        Long commentId
+) {
+}

--- a/src/main/java/org/sopt/certi_server/domain/comment/service/CertificationCommentService.java
+++ b/src/main/java/org/sopt/certi_server/domain/comment/service/CertificationCommentService.java
@@ -1,5 +1,6 @@
 package org.sopt.certi_server.domain.comment.service;
 
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.sopt.certi_server.domain.acquisition.entity.Acquisition;
 import org.sopt.certi_server.domain.acquisition.repository.AcquisitionRepository;
@@ -7,6 +8,7 @@ import org.sopt.certi_server.domain.certification.entity.Certification;
 import org.sopt.certi_server.domain.certification.service.CertificationService;
 import org.sopt.certi_server.domain.comment.dto.response.CertificationCommentResponse;
 import org.sopt.certi_server.domain.comment.dto.request.CommentRegisterRequest;
+import org.sopt.certi_server.domain.comment.dto.response.CommentCreateResponse;
 import org.sopt.certi_server.domain.comment.entity.CertificationComment;
 import org.sopt.certi_server.domain.comment.entity.CertificationCommentLike;
 import org.sopt.certi_server.domain.comment.repository.CertificationCommentLikeRepository;
@@ -40,6 +42,7 @@ public class CertificationCommentService {
     private final AcquisitionRepository acquisitionRepository;
     private final UserPreCertificationRepository userPreCertificationRepository;
     private final UserJobRepository userJobRepository;
+    private final EntityManager em;
 
     /**
      * 댓글 등록 메서드
@@ -48,7 +51,7 @@ public class CertificationCommentService {
      * @param request
      */
     @Transactional
-    public void registerComment(
+    public CommentCreateResponse registerComment(
             final Long userId,
             final CommentRegisterRequest request
     ){
@@ -71,7 +74,10 @@ public class CertificationCommentService {
                 .content(request.content())
                 .build();
 
+        em.flush();
         certificationCommentRepository.save(newCertificationComment);
+
+        return new CommentCreateResponse(newCertificationComment.getId());
     }
 
 

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/response/GetUserResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/response/GetUserResponse.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 
 @Builder
 public record GetUserResponse(
+        Long userId,
         String nickname,
         String name,
         String university,
@@ -18,6 +19,7 @@ public record GetUserResponse(
 ) {
     public static GetUserResponse from(User user, MajorImpl majorImpl, int percentage) {
         return GetUserResponse.builder()
+                .userId(user.getId())
                 .nickname(user.getNickname())
                 .name(user.getName())
                 .university(user.getUniversity().getName())

--- a/src/main/java/org/sopt/certi_server/domain/user/dto/response/GetUserResponse.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/dto/response/GetUserResponse.java
@@ -1,6 +1,7 @@
 package org.sopt.certi_server.domain.user.dto.response;
 
 import lombok.Builder;
+import org.sopt.certi_server.domain.job.entity.Job;
 import org.sopt.certi_server.domain.major.entity.MajorImpl;
 import org.sopt.certi_server.domain.user.entity.User;
 
@@ -13,17 +14,19 @@ public record GetUserResponse(
         String name,
         String university,
         String major,
+        String job,
         String profileImage,
         LocalDate birthDate,
         int percentage
 ) {
-    public static GetUserResponse from(User user, MajorImpl majorImpl, int percentage) {
+    public static GetUserResponse from(User user, MajorImpl majorImpl, Job job, int percentage) {
         return GetUserResponse.builder()
                 .userId(user.getId())
                 .nickname(user.getNickname())
                 .name(user.getName())
                 .university(user.getUniversity().getName())
                 .major(majorImpl.getName())
+                .job(job.getName())
                 .profileImage(user.getProfileImageUrl())
                 .percentage(percentage)
                 .birthDate(user.getBirthDate())

--- a/src/main/java/org/sopt/certi_server/domain/user/service/GoogleService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/GoogleService.java
@@ -64,9 +64,10 @@ public class GoogleService implements SocialService{
     public OAuthUserInformation getUserInfoByAccessToken(String token) {
         try{
             log.info("google access token: {}", token);
-            verifyToken(token);
-            GoogleUserInformation information = googleApiFeignClient.getUserInfo("Bearer " + token);
-            return OAuthUserInformation.from(information);
+
+            // 구글은 access token을 클라이언트에서 발급받는 방식이 anti pattern
+            // 따라서 id token을 분석해 사용자 정보를 추출한다.
+            return getUserInfoByIdToken(token);
         }catch (Exception e) {
             log.error("google user data 획득 실패: {}", e.getMessage());
             throw e;

--- a/src/main/java/org/sopt/certi_server/domain/user/service/GoogleService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/GoogleService.java
@@ -55,6 +55,7 @@ public class GoogleService implements SocialService{
     @Override
     public OAuthUserInformation getUserInfoByAccessToken(String token) {
         try{
+            log.info("google access token: {}", token);
             GoogleUserInformation information = googleApiFeignClient.getUserInfo("Bearer " + token);
             return OAuthUserInformation.from(information);
         }catch (Exception e) {

--- a/src/main/java/org/sopt/certi_server/domain/user/service/GoogleService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/GoogleService.java
@@ -71,6 +71,14 @@ public class GoogleService implements SocialService{
         }
     }
 
+    // access token이 아닌, id token 방식
+    public OAuthUserInformation getUserInfoByIdToken(String idToken){
+
+        GoogleUserInformation googleUserInformation = verifyToken(idToken);
+
+        return OAuthUserInformation.from(googleUserInformation);
+    }
+
     public GoogleOAuthResponse getOAuthToken(String code){
         try{
             return googleOAuthFeignClient.getToken(
@@ -87,7 +95,7 @@ public class GoogleService implements SocialService{
         }
     }
 
-    public void verifyToken(String idTokenString) {
+    public GoogleUserInformation verifyToken(String idTokenString) {
         GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), new GsonFactory())
                 // 내 앱의 Client ID를 설정 (중요: 다른 앱에서 발급된 토큰을 차단함)
                 .setAudience(Collections.singletonList(googleClientId))
@@ -109,6 +117,8 @@ public class GoogleService implements SocialService{
 
                 log.info("User ID: {}", userId);
                 log.info("Email: {}", email);
+
+                return new GoogleUserInformation(userId, name, null, null, pictureUrl, email, false, null);
             } else {
                 System.out.println("유효하지 않은 토큰입니다.");
             }

--- a/src/main/java/org/sopt/certi_server/domain/user/service/GoogleService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/GoogleService.java
@@ -13,6 +13,8 @@ import org.sopt.certi_server.domain.user.dto.response.google.GoogleOAuthResponse
 import org.sopt.certi_server.domain.user.dto.response.google.GoogleUserInformation;
 import org.sopt.certi_server.global.client.google.GoogleApiFeignClient;
 import org.sopt.certi_server.global.client.google.GoogleOAuthFeignClient;
+import org.sopt.certi_server.global.error.code.ErrorCode;
+import org.sopt.certi_server.global.error.exception.BusinessException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -126,5 +128,6 @@ public class GoogleService implements SocialService{
             log.error("구글 ID 토큰 파싱 실패");
             e.printStackTrace();
         }
+        throw new BusinessException(ErrorCode.BAD_REQUEST_DATA);
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/service/GoogleService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/GoogleService.java
@@ -1,5 +1,9 @@
 package org.sopt.certi_server.domain.user.service;
 
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.certi_server.domain.user.dto.request.google.GoogleTokenRequest;
@@ -11,6 +15,8 @@ import org.sopt.certi_server.global.client.google.GoogleApiFeignClient;
 import org.sopt.certi_server.global.client.google.GoogleOAuthFeignClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.Collections;
 
 @RequiredArgsConstructor
 @Service
@@ -56,6 +62,7 @@ public class GoogleService implements SocialService{
     public OAuthUserInformation getUserInfoByAccessToken(String token) {
         try{
             log.info("google access token: {}", token);
+            verifyToken(token);
             GoogleUserInformation information = googleApiFeignClient.getUserInfo("Bearer " + token);
             return OAuthUserInformation.from(information);
         }catch (Exception e) {
@@ -77,6 +84,37 @@ public class GoogleService implements SocialService{
         }catch (Exception e) {
             log.error("google oauth token 발급 실패: {}", e.getMessage());
             throw e;
+        }
+    }
+
+    public void verifyToken(String idTokenString) {
+        GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), new GsonFactory())
+                // 내 앱의 Client ID를 설정 (중요: 다른 앱에서 발급된 토큰을 차단함)
+                .setAudience(Collections.singletonList(googleClientId))
+                .build();
+
+        try {
+            // 1. 토큰 검증 (서명 확인, 만료 여부 확인 등)
+            GoogleIdToken idToken = verifier.verify(idTokenString);
+
+            if (idToken != null) {
+                // 2. 복호화된 페이로드(내용물) 가져오기
+                GoogleIdToken.Payload payload = idToken.getPayload();
+
+                // 3. 사용자 정보 추출
+                String userId = payload.getSubject();    // 구글의 유니크한 사용자 ID
+                String email = payload.getEmail();       // 이메일
+                String name = (String) payload.get("name"); // 이름
+                String pictureUrl = (String) payload.get("picture"); // 프로필 사진
+
+                log.info("User ID: {}", userId);
+                log.info("Email: {}", email);
+            } else {
+                System.out.println("유효하지 않은 토큰입니다.");
+            }
+        } catch (Exception e) {
+            log.error("구글 ID 토큰 파싱 실패");
+            e.printStackTrace();
         }
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/certi_server/domain/user/service/UserService.java
@@ -57,13 +57,13 @@ public class UserService {
     public GetUserResponse getHomeUser(final Long userId) {
         User user = getUser(userId);
         List<MajorImpl> majorList = majorImplRepository.findMajorImplByUser(user);
-
+        List<Job> jobList = jobRepository.findAllByUser(user);
         if(majorList.isEmpty()){
             throw new NotFoundException(ErrorCode.MAJOR_NOT_FOUND);
         }
 
         int percentage = calculateResumeProgress(user);
-        return GetUserResponse.from(user, majorList.get(0), percentage);
+        return GetUserResponse.from(user, majorList.get(0), jobList.get(0), percentage);
     }
 
     public GetJobResponse getUserJob(final Long userId) {

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/dto/response/PreCertificationSimple.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/dto/response/PreCertificationSimple.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 
 public record PreCertificationSimple(
         Long certificationId,
+        Long preCertificationId,
         String certificationName,
         String certificationType,
         String description,
@@ -23,6 +24,7 @@ public record PreCertificationSimple(
     public static PreCertificationSimple from(UserPreCertification upc) {
         return new PreCertificationSimple(
                 upc.getCertification().getId(),
+                upc.getId(),
                 upc.getCertification().getName(),
                 upc.getCertification().getCertificationType().getKoreanName(),
                 upc.getCertification().getDescription(),


### PR DESCRIPTION
## 📣 Related Issue

- close #206 

## 📝 Summary

- 구글 로그인 오류를 해결합니다.
- 취득 예정 리스트 조회 시 dto에 preCertificationId가 추가되었습니다.

## 🙏 Question & PR point

- N/A

## 📬 Postman


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 자격증 사전인증 응답에 사전인증 ID가 포함되어 인증 항목 식별·추적이 개선되었습니다.
  * 사용자 조회 응답에 사용자 ID와 직업 정보(job)가 추가되어 클라이언트에서 사용자 프로필 표시가 풍부해졌습니다.
  * 댓글 등록 시 생성된 댓글 ID를 반환하고, 등록 API가 생성된 댓글 정보를 응답하도록 개선되어 즉시 확인 가능합니다.
  * Google 로그인에 ID 토큰 기반 서버측 검증이 도입되어 인증 신뢰성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->