### PR TITLE
#222 [hotfix] db 제약 조건 삭제

### DIFF
--- a/src/main/java/org/sopt/certi_server/domain/comment/controller/CertificationCommentController.java
+++ b/src/main/java/org/sopt/certi_server/domain/comment/controller/CertificationCommentController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.sopt.certi_server.domain.comment.dto.request.CommentRegisterRequest;
+import org.sopt.certi_server.domain.comment.dto.request.CommentSortType;
 import org.sopt.certi_server.domain.comment.dto.response.CertificationCommentResponse;
 import org.sopt.certi_server.domain.comment.dto.response.CommentCreateResponse;
 import org.sopt.certi_server.domain.comment.service.CertificationCommentService;
@@ -48,16 +49,12 @@ public class CertificationCommentController {
     @GetMapping
     @Operation(summary = "댓글 조회 API", description = "해당 자격증의 댓글을 조회합니다.")
     public ResponseEntity<SuccessResponse<PageResponse<CertificationCommentResponse>>> getCommentList(
-        @AuthenticationPrincipal Long userId,
-        @RequestParam(value = "certificationId") Long certificationId,
-        @PageableDefault(
-                page = 0,
-                size = 10,
-                sort = "createdTime",
-                direction = Sort.Direction.DESC
-        ) final Pageable pageable
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(value = "certificationId") Long certificationId,
+            @RequestParam(defaultValue = "LATEST") CommentSortType commentSortType,
+            @PageableDefault(page = 0, size = 12) final Pageable pageable
     ){
-        Page<CertificationCommentResponse> responsePage = certificationCommentService.getCommentsByCertification(userId, certificationId, pageable);
+        Page<CertificationCommentResponse> responsePage = certificationCommentService.getCommentsByCertification(userId, certificationId, pageable, commentSortType);
 
         PageResponse<CertificationCommentResponse> responsePageDto = PageResponse.from(responsePage);
 

--- a/src/main/java/org/sopt/certi_server/domain/comment/dto/request/CommentSortType.java
+++ b/src/main/java/org/sopt/certi_server/domain/comment/dto/request/CommentSortType.java
@@ -1,0 +1,6 @@
+package org.sopt.certi_server.domain.comment.dto.request;
+
+public enum CommentSortType {
+    LATEST,
+    POPULAR
+}

--- a/src/main/java/org/sopt/certi_server/domain/comment/repository/CertificationCommentRepositoryCustomImpl.java
+++ b/src/main/java/org/sopt/certi_server/domain/comment/repository/CertificationCommentRepositoryCustomImpl.java
@@ -25,7 +25,6 @@ public class CertificationCommentRepositoryCustomImpl implements CertificationCo
 
     @Override
     public Page<CertificationComment> findByCertificationId(Long certificationId, Long userId, Pageable pageable) {
-
         QUserBlock block = QUserBlock.userBlock;
         QCertificationComment comment = QCertificationComment.certificationComment;
 

--- a/src/main/java/org/sopt/certi_server/domain/comment/service/CertificationCommentService.java
+++ b/src/main/java/org/sopt/certi_server/domain/comment/service/CertificationCommentService.java
@@ -2,10 +2,12 @@ package org.sopt.certi_server.domain.comment.service;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.certi_server.domain.acquisition.entity.Acquisition;
 import org.sopt.certi_server.domain.acquisition.repository.AcquisitionRepository;
 import org.sopt.certi_server.domain.certification.entity.Certification;
 import org.sopt.certi_server.domain.certification.service.CertificationService;
+import org.sopt.certi_server.domain.comment.dto.request.CommentSortType;
 import org.sopt.certi_server.domain.comment.dto.response.CertificationCommentResponse;
 import org.sopt.certi_server.domain.comment.dto.request.CommentRegisterRequest;
 import org.sopt.certi_server.domain.comment.dto.response.CommentCreateResponse;
@@ -23,7 +25,9 @@ import org.sopt.certi_server.global.error.code.ErrorCode;
 import org.sopt.certi_server.global.error.exception.NotFoundException;
 import org.sopt.certi_server.global.error.exception.UnauthorizedException;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +37,7 @@ import java.util.stream.Collectors;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class CertificationCommentService {
 
     private final UserService userService;
@@ -85,15 +90,23 @@ public class CertificationCommentService {
      * 자격증의 댓글을 조회하는 메서드
      *
      * @param certificationId
-     * @param pageble
+     * @param pageable
      * @return
      */
     public Page<CertificationCommentResponse> getCommentsByCertification(
             final Long userId,
             final Long certificationId,
-            final Pageable pageble
-    ){
-        Page<CertificationComment> commentPage = certificationCommentRepository.findByCertificationId(certificationId, userId, pageble);
+            final Pageable pageable,
+            final CommentSortType commentSortType
+            ){
+
+        Pageable sortedPageable = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                getSort(commentSortType)
+        );
+
+        Page<CertificationComment> commentPage = certificationCommentRepository.findByCertificationId(certificationId, userId, sortedPageable);
 
         List<User> users = commentPage.getContent().stream()
                 .map(CertificationComment::getUser)
@@ -220,5 +233,15 @@ public class CertificationCommentService {
     public CertificationComment getComment(Long commentId){
         return certificationCommentRepository.findById(commentId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+    }
+
+    private Sort getSort(CommentSortType commentSortType) {
+        return switch (commentSortType) {
+            case LATEST -> Sort.by(Sort.Direction.DESC, "createdTime");
+            case POPULAR -> Sort.by(
+                    Sort.Order.desc("likeCount"),
+                    Sort.Order.desc("createdTime")
+            );
+        };
     }
 }

--- a/src/main/java/org/sopt/certi_server/domain/userprecertification/entity/UserPreCertification.java
+++ b/src/main/java/org/sopt/certi_server/domain/userprecertification/entity/UserPreCertification.java
@@ -40,7 +40,7 @@ public class UserPreCertification extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private IconType iconType;
 
-    @Column(name = "test_date", nullable = false)
+    @Column(name = "test_date")
     private LocalDateTime testDate;
 
     @Embedded

--- a/src/test/java/org/sopt/certi_server/domain/comment/service/CertificationCommentServiceTest.java
+++ b/src/test/java/org/sopt/certi_server/domain/comment/service/CertificationCommentServiceTest.java
@@ -10,6 +10,7 @@ import org.sopt.certi_server.domain.acquisition.repository.AcquisitionRepository
 import org.sopt.certi_server.domain.certification.entity.Certification;
 import org.sopt.certi_server.domain.certification.repository.CertificationRepository;
 import org.sopt.certi_server.domain.comment.dto.request.CommentRegisterRequest;
+import org.sopt.certi_server.domain.comment.dto.request.CommentSortType;
 import org.sopt.certi_server.domain.comment.dto.response.CertificationCommentResponse;
 import org.sopt.certi_server.domain.comment.entity.CertificationComment;
 import org.sopt.certi_server.domain.comment.entity.CertificationCommentLike;
@@ -88,7 +89,7 @@ class CertificationCommentServiceTest {
     void setUp() {
 
         testUniversity = universityRepository.findById(1L).orElseThrow();
-        testMajor = majorImplRepository.findMajorImplByName("전산학/컴퓨터공학").orElseThrow();
+        testMajor = majorImplRepository.findMajorImplByName("컴퓨터공학과").orElseThrow();
         // Mocking 대신 실제 DB에 데이터 저장
         testUser = userRepository.save(User.builder()
                 .email("lee@gmail.com")
@@ -278,7 +279,8 @@ class CertificationCommentServiceTest {
             // Given
             Long userId = testUser.getId();
             Long certificationId = testCertification.getId();
-            Pageable pageable = PageRequest.of(0, 10);
+            Pageable pageable = PageRequest.of(0, 12);
+            CommentSortType commentSortType = CommentSortType.LATEST;
 
             // 1. 직무 정보 DB에 저장
             userJobRepository.save(UserJob.builder().user(testUser).job(testJob).build());
@@ -296,7 +298,7 @@ class CertificationCommentServiceTest {
                     .build());
 
             // When
-            Page<CertificationCommentResponse> responsePage = certificationCommentService.getCommentsByCertification(userId, certificationId, pageable);
+            Page<CertificationCommentResponse> responsePage = certificationCommentService.getCommentsByCertification(userId, certificationId, pageable, commentSortType);
 
             // Then
             // 1. DTO가 올바르게 조립되었는지 검증


### PR DESCRIPTION
## 📣 Related Issue

- close #222 

## 📝 Summary

- DB 제약조건으로 인해 취득 예정이 추가되지 않는 오류를 해결했습니다.

## 🙏 Question & PR point

- N/A

## 📬 Postman

<img width="581" height="514" alt="image" src="https://github.com/user-attachments/assets/e67bfb16-5db6-4454-ad90-212c18471e7c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 사전 인증 프로세스에서 시험 날짜 입력이 선택사항으로 변경되었습니다.

* **New Features**
  * 댓글 정렬 옵션(LATEST, POPULAR)이 추가되어 조회 시 정렬 기준을 선택할 수 있습니다.
  * 댓글 목록 기본 페이지 크기가 12로 조정되었습니다 (기본 정렬: LATEST).

* **Tests**
  * 댓글 서비스 관련 테스트가 새로운 정렬 파라미터와 페이지 크기에 맞게 갱신되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->